### PR TITLE
v0.44: report Mighty milestone version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ For the full per-release notes, see
 
 ## [Unreleased]
 
-- Next-cycle work remains tracked in GitHub issues and the docs backlog.
+v0.44 development focuses on removing the remaining IDE-dogfooding
+trust gaps that make agent-built apps harder to diagnose.
+
+### Fixed
+- **L9:** `mty --version` now reports the Mighty language/toolchain
+  milestone (`0.44.0-dev` on main) instead of the internal Rust crate
+  version `0.1.0`. The agent HTTP `/v1/agent/version` endpoint uses
+  the same public version source.
 
 ## [0.43.0] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ statement-form `Vec`/`String` mutators (`v.push(x)`, `v.pop()`,
 parsing (`!pred(x)`), truthful native-link diagnostics after object
 emission, LSP document symbols, and Windows control pipes.
 
+`main` is now the v0.44 development line; dev builds report
+`mty 0.44.0-dev` so bug reports and agent telemetry point at the
+Mighty milestone rather than the internal Rust crate version.
+
 ## Why Mighty
 
 Mighty is the first compiler-backed agent language with

--- a/crates/mty-cli/src/cmd/agent.rs
+++ b/crates/mty-cli/src/cmd/agent.rs
@@ -1492,7 +1492,7 @@ async fn http_handle(
     match (method.as_str(), path.as_str()) {
         ("GET", "/v1/agent/version") => {
             let body = serde_json::json!({
-                "mty_version": env!("CARGO_PKG_VERSION"),
+                "mty_version": crate::MIGHTY_VERSION,
                 "agent_protocol": "1.0",
             });
             hyper::Response::builder()

--- a/crates/mty-cli/src/lib.rs
+++ b/crates/mty-cli/src/lib.rs
@@ -18,6 +18,14 @@
 #[cfg(feature = "host-toolchain")]
 pub mod cmd;
 
+/// User-facing Mighty language/toolchain milestone.
+///
+/// The Rust workspace crates intentionally keep their internal crate
+/// version while the public toolchain advances by Mighty milestones
+/// (`v0.43.0`, `v0.44.0-dev`, ...). Keep this aligned with
+/// `CHANGELOG.md` and release tags.
+pub const MIGHTY_VERSION: &str = "0.44.0-dev";
+
 // v0.35 T1 — browser playground exports. `wasm-pack build --target web`
 // reads this cdylib's `#[wasm_bindgen]` symbols (`init` / `check` /
 // `run`) and emits the JS glue under

--- a/crates/mty-cli/src/main.rs
+++ b/crates/mty-cli/src/main.rs
@@ -8,7 +8,7 @@ use clap::{Args, Parser, Subcommand};
 use mty_cli::cmd;
 
 #[derive(Parser)]
-#[command(name = "mty", version, about = "Mighty compiler CLI")]
+#[command(name = "mty", version = mty_cli::MIGHTY_VERSION, about = "Mighty compiler CLI")]
 struct Cli {
     #[command(subcommand)]
     cmd: Cmd,

--- a/crates/mty-cli/tests/agent_http.rs
+++ b/crates/mty-cli/tests/agent_http.rs
@@ -135,7 +135,7 @@ fn version_endpoint_returns_protocol_and_mty_version() {
         .any(|(k, v)| k == "content-type" && v.contains("application/json")));
     let v: serde_json::Value = serde_json::from_slice(&body).expect("json");
     assert_eq!(v["agent_protocol"], "1.0");
-    assert!(v["mty_version"].as_str().unwrap().contains('.'));
+    assert_eq!(v["mty_version"], mty_cli::MIGHTY_VERSION);
     kill(&mut child);
 }
 

--- a/crates/mty-cli/tests/cmd_version.rs
+++ b/crates/mty-cli/tests/cmd_version.rs
@@ -1,0 +1,23 @@
+#![cfg(feature = "host-toolchain")]
+
+use std::process::Command;
+
+#[test]
+fn mty_version_reports_language_milestone() {
+    let out = Command::new(env!("CARGO_BIN_EXE_mty"))
+        .arg("--version")
+        .output()
+        .expect("run mty --version");
+    assert!(out.status.success(), "mty --version should succeed");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(mty_cli::MIGHTY_VERSION),
+        "expected version output to contain {}, got {stdout:?}",
+        mty_cli::MIGHTY_VERSION
+    );
+    assert!(
+        !stdout.contains("0.1.0"),
+        "public CLI version should not expose the internal crate version: {stdout:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a public Mighty milestone version constant for dev builds
- wire `mty --version` and `/v1/agent/version` to the milestone version instead of the internal crate version
- document the v0.44 development line and add regression coverage

## Tests
- `cargo test -p mty-cli --test cmd_version`
- `cargo test -p mty-cli --test agent_http version_endpoint_returns_protocol_and_mty_version`
- `cargo fmt --check`
- `cargo clippy -p mty-cli --all-targets -- -D warnings`
- pre-push hook: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `mty fmt --check`