### PR TITLE
v0.44: avoid parser stack growth for else-if ladders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ trust gaps that make agent-built apps harder to diagnose.
   milestone (`0.44.0-dev` on main) instead of the internal Rust crate
   version `0.1.0`. The agent HTTP `/v1/agent/version` endpoint uses
   the same public version source.
+- **L37:** long top-level `else if` ladders now parse without growing
+  the Rust call stack once per arm. The CST shape remains the same for
+  downstream lowering/typechecking, but the parser consumes the ladder
+  iteratively, so agent-generated command routers and IDE key
+  dispatchers can grow without tripping `thread 'main' has overflowed
+  its stack`.
 
 ## [0.43.0] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ emission, LSP document symbols, and Windows control pipes.
 
 `main` is now the v0.44 development line; dev builds report
 `mty 0.44.0-dev` so bug reports and agent telemetry point at the
-Mighty milestone rather than the internal Rust crate version.
+Mighty milestone rather than the internal Rust crate version. v0.44 is
+also hardening agent-generated app shapes: long `else if` command
+routers now parse iteratively, preserving the normal tree while
+avoiding stack overflow in large IDE-style dispatch ladders.
 
 ## Why Mighty
 

--- a/crates/mty-syntax/src/parser/stmts.rs
+++ b/crates/mty-syntax/src/parser/stmts.rs
@@ -52,33 +52,39 @@ fn let_stmt(p: &mut Parser) {
 }
 
 pub fn if_expr(p: &mut Parser) -> bool {
-    p.start_node(IF_EXPR);
-    p.bump(IF_KW);
-    p.skip_trivia();
-    // `if let Pattern = scrutinee { ... }` — optional leading let-binding.
-    // The CST shape is the same IF_EXPR; HIR lowering branches on whether
-    // a LET_KW token is present.
-    if p.at(LET_KW) {
-        p.bump(LET_KW);
+    let mut open_ifs = 0usize;
+    loop {
+        p.start_node(IF_EXPR);
+        open_ifs += 1;
+        p.bump(IF_KW);
         p.skip_trivia();
-        patterns::pattern(p);
-        p.expect(EQ);
-        p.skip_trivia();
-    }
-    // Disable struct-literal parsing for the condition so `if x { ... }`
-    // parses as condition + body, not as `x { ... }` struct expr.
-    p.with_no_struct_literal(|p| {
-        exprs::expr(p);
-    });
-    block(p);
-    if p.eat(ELSE_KW) {
-        if p.at(IF_KW) {
-            if_expr(p);
-        } else {
+        // `if let Pattern = scrutinee { ... }` — optional leading let-binding.
+        // The CST shape is the same IF_EXPR; HIR lowering branches on whether
+        // a LET_KW token is present.
+        if p.at(LET_KW) {
+            p.bump(LET_KW);
+            p.skip_trivia();
+            patterns::pattern(p);
+            p.expect(EQ);
+            p.skip_trivia();
+        }
+        // Disable struct-literal parsing for the condition so `if x { ... }`
+        // parses as condition + body, not as `x { ... }` struct expr.
+        p.with_no_struct_literal(|p| {
+            exprs::expr(p);
+        });
+        block(p);
+        if !p.eat(ELSE_KW) {
+            break;
+        }
+        if !p.at(IF_KW) {
             block(p);
+            break;
         }
     }
-    p.finish_node();
+    for _ in 0..open_ifs {
+        p.finish_node();
+    }
     true
 }
 

--- a/crates/mty-syntax/tests/parse_stmts.rs
+++ b/crates/mty-syntax/tests/parse_stmts.rs
@@ -170,3 +170,23 @@ fn main() {
         .descendants()
         .any(|n| n.kind() == SyntaxKind::CALL_EXPR));
 }
+
+#[test]
+fn parse_long_else_if_ladder_without_stack_growth() {
+    use mty_syntax::{parse, SyntaxKind, SyntaxNode};
+
+    let mut src = String::from("fn f(x: I32) -> I32 { if x == 0 { 0 }");
+    for i in 1..512 {
+        src.push_str(&format!(" else if x == {i} {{ {i} }}"));
+    }
+    src.push_str(" else { -1 } }");
+
+    let r = parse(&src);
+    assert!(r.errors.is_empty(), "errors: {:?}", r.errors);
+    let root = SyntaxNode::new_root(r.green);
+    let if_count = root
+        .descendants()
+        .filter(|n| n.kind() == SyntaxKind::IF_EXPR)
+        .count();
+    assert_eq!(if_count, 512);
+}

--- a/dev/README.md
+++ b/dev/README.md
@@ -12,7 +12,7 @@ of how the toolchain got built slice-by-slice.
   v0.1's eight ladder slices onward (slice-based development was
   superseded by track-based releases at v0.20).
 - [`history/releases/`](history/releases/) — the full per-release
-  notes (`RELEASE-v0.1.md` .. `RELEASE-v0.36.md`). The repo-root
+  notes (`RELEASE-v0.1.md` .. `RELEASE-v0.44.md`). The repo-root
   [`CHANGELOG.md`](../CHANGELOG.md) summarises each; this directory
   holds the unabridged versions.
 - [`history/notes/`](history/notes/) — agent-level working notes

--- a/dev/history/README.md
+++ b/dev/history/README.md
@@ -55,6 +55,8 @@ and later (the track-driven era) consult the individual
 - v0.43 draft — IDE dogfooding correctness rollup: short-circuit lowering,
   interpreter mutator writeback, top-level `const` formatting, prefix-call
   parsing, and native link diagnostics
+- v0.44 draft — public Mighty milestone versioning plus parser resilience for
+  long agent-generated `else if` command ladders
 
 | File | Headline |
 |---|---|

--- a/dev/history/releases/RELEASE-v0.44.md
+++ b/dev/history/releases/RELEASE-v0.44.md
@@ -1,0 +1,46 @@
+# Mighty v0.44 - Draft Release Notes
+
+**Tag:** `v0.44.0`
+**Date:** TBD
+**Status:** DRAFT - agentic app reliability and release identity.
+
+**Headline:** make Mighty easier for agents to build and debug by
+closing trust gaps surfaced by Mighty IDE dogfooding.
+
+## Summary
+
+v0.44 starts by making the toolchain identify itself with the public
+Mighty milestone, then removes a parser stack ceiling hit by large
+agent-authored command routers. The theme for this release is simple:
+generated app code should fail with useful diagnostics, not with stale
+versions, silent defaults, or process-level stack overflows.
+
+## Release candidates
+
+- **L9:** `mty --version` reports the Mighty language/toolchain
+  milestone (`0.44.0-dev` on main) instead of the internal Rust crate
+  version `0.1.0`. The agent HTTP `/v1/agent/version` endpoint uses
+  the same public version source.
+- **L37:** `else if` ladders parse iteratively while preserving the
+  nested `IF_EXPR` CST shape. A 512-arm ladder now passes parser
+  regression coverage and `mty check`, removing the practical ceiling
+  hit by Mighty IDE key/command dispatch growth.
+
+## Validation plan
+
+- Keep the full CI matrix green before tagging: Ubuntu, macOS,
+  Windows, minimal features, strict clippy, MSRV, build smoke,
+  `mty-bench`, and `cargo audit`.
+- Run focused parser, CLI, and driver checks for every IDE-dogfooding
+  fix included in the release.
+- Keep `main` protected. Use admin merge only to move green PRs through
+  branch rules; do not weaken checks, force-push protection, or delete
+  protection.
+
+## Carry-forward priorities
+
+- **L18 (P1):** expose `std.fs` as a Mighty-callable capability API so
+  built Mighty apps can save/load without a Rust shim owning file I/O.
+- Broaden formatter rollout beyond safe top-level item shapes.
+- Continue replacing scalar ABI pain points with structured result and
+  command surfaces that agents can generate without manual id mirrors.


### PR DESCRIPTION
## Summary
- parse chained else-if ladders iteratively while preserving nested IF_EXPR CST shape
- add a 512-arm parser regression and verify the same generated shape with mty check locally
- advance v0.44 release docs, changelog, README, and dev history index

## Validation
- cargo fmt --check
- cargo test -p mty-syntax --test parse_stmts
- cargo test -p mty-syntax
- cargo clippy -p mty-syntax --all-targets -- -D warnings
- git diff --check
- generated 512-arm else-if ladder: target\\debug\\mty.exe check %TEMP%\\mty-long-else-if.mty
- pre-push hook: cargo fmt --all -- --check; cargo clippy --workspace --all-targets -- -D warnings; mty fmt --check on .mty files