### PR TITLE
v0.44: route std fs run fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ trust gaps that make agent-built apps harder to diagnose.
   iteratively, so agent-generated command routers and IDE key
   dispatchers can grow without tripping `thread 'main' has overflowed
   its stack`.
+- **L18:** default `mty run` now treats host-backed `std.fs` calls as
+  interpreter-hosted when the Cranelift JIT sees them, returning the
+  normal fallback signal instead of compiling them through the generic
+  native extern stub. The stdlib host dispatcher also accepts common
+  agent spellings (`read_file`, `read_to_string`, `write_file`,
+  `write_string`, and `read_dir`) alongside the existing `std.fs`
+  names.
 
 ## [0.43.0] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ emission, LSP document symbols, and Windows control pipes.
 `mty 0.44.0-dev` so bug reports and agent telemetry point at the
 Mighty milestone rather than the internal Rust crate version. v0.44 is
 also hardening agent-generated app shapes: long `else if` command
-routers now parse iteratively, preserving the normal tree while
-avoiding stack overflow in large IDE-style dispatch ladders.
+routers now parse iteratively, and default `mty run` falls back to the
+interpreter for host-backed `std.fs` calls instead of routing them
+through the native extern stub.
 
 ## Why Mighty
 

--- a/crates/mty-codegen-cranelift/src/lower.rs
+++ b/crates/mty-codegen-cranelift/src/lower.rs
@@ -925,9 +925,16 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
                 // Slice-8 stub: route through extern_call with the
                 // method name. The runtime stub returns 0 — the
                 // compiled program continues with a zero-default value.
-                let method = match op {
-                    mty_ir::ir::EffectOp::GenericCall { path: _, method } => method.clone(),
+                let (path, method) = match op {
+                    mty_ir::ir::EffectOp::GenericCall { path, method } => (path, method),
                 };
+                let full_name = effect_full_name(path, method);
+                if is_interpreter_hosted_stdlib(&full_name) {
+                    return Err(CodegenError::Unsupported(format!(
+                        "{full_name} is interpreter-hosted"
+                    )));
+                }
+                let method = method.clone();
                 let id = self.mod_ctx.intern_string(&method)?;
                 let gv = self.mod_ctx.module.declare_data_in_func(id, self.b.func);
                 let nptr = self.b.ins().symbol_value(ct::I64, gv);
@@ -2634,6 +2641,11 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
                 self.emit_vec_new()
             }
             FnRef::Builtin(BuiltinId::Extern(name)) => {
+                if is_interpreter_hosted_stdlib(name) {
+                    return Err(CodegenError::Unsupported(format!(
+                        "{name} is interpreter-hosted"
+                    )));
+                }
                 // Generic extern: route through the runtime ABI bridge.
                 // Slice-8 lowers this to a no-op-return stub (the
                 // runtime's extern_call returns i64). Real argument
@@ -3734,6 +3746,29 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
         _ret_ty: Option<cranelift_codegen::ir::Type>,
     ) -> CompileResult<Option<cranelift_codegen::ir::Value>> {
         self.call_rt(name, &[], _ret_ty)
+    }
+}
+
+fn is_interpreter_hosted_stdlib(name: &str) -> bool {
+    matches!(
+        name,
+        "std.fs.read"
+            | "std.fs.read_file"
+            | "std.fs.read_to_string"
+            | "std.fs.write"
+            | "std.fs.write_file"
+            | "std.fs.write_string"
+            | "std.fs.exists"
+            | "std.fs.list_dir"
+            | "std.fs.read_dir"
+    )
+}
+
+fn effect_full_name(path: &[String], method: &str) -> String {
+    if path.is_empty() {
+        method.to_string()
+    } else {
+        format!("{}.{}", path.join("."), method)
     }
 }
 

--- a/crates/mty-driver/src/build.rs
+++ b/crates/mty-driver/src/build.rs
@@ -460,6 +460,24 @@ mod tests {
     }
 
     #[test]
+    fn jit_run_interpreter_hosted_std_fs_returns_fallback_signal() {
+        let src = r#"
+use std.fs
+
+fn main() {
+  std.fs.write("__mighty_jit_fallback_probe__.txt", "hello")
+  let body = std.fs.read("__mighty_jit_fallback_probe__.txt")
+  if body != "hello" { panic(body) }
+}
+"#
+        .to_string();
+        match jit_run(src, "fs.mty".into()) {
+            Ok(None) => {}
+            other => panic!("expected JIT fallback signal for std.fs, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn build_native_creates_object() {
         let _guard = LINKER_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/mty-driver/tests/conformance_codegen.rs
+++ b/crates/mty-driver/tests/conformance_codegen.rs
@@ -226,8 +226,10 @@ fn is_typeck_pending(src: &str) -> bool {
 }
 
 /// Sweep all ship examples through the cranelift JIT path. Each
-/// example should produce a valid object — failures here surface as
-/// codegen regressions. (Linker-availability is not required.)
+/// example should produce a valid object unless it intentionally
+/// exercises an interpreter-hosted stdlib surface that `mty run`
+/// falls back for. Failures here surface as codegen regressions.
+/// Linker availability is not required.
 #[test]
 fn all_examples_compile_native() {
     let examples_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -249,7 +251,11 @@ fn all_examples_compile_native() {
         let st = codegen_abi::symbol_table();
         let syms = symbols_from(&st.iter().map(|(n, p)| (n.as_str(), *p)).collect::<Vec<_>>());
         if let Err(e) = build_jit(&prog, &syms) {
-            failed.push((name, format!("{e}")));
+            let err = format!("{e}");
+            if is_interpreter_hosted_std_fs_codegen(&err) {
+                continue;
+            }
+            failed.push((name, err));
         }
     }
     assert!(
@@ -262,6 +268,10 @@ fn all_examples_compile_native() {
             .collect::<Vec<_>>()
             .join("\n")
     );
+}
+
+fn is_interpreter_hosted_std_fs_codegen(err: &str) -> bool {
+    err.contains("std.fs.") && err.contains("is interpreter-hosted")
 }
 
 /// JIT-run smoke: for each adt/match/result/agent/mono case, JIT the

--- a/crates/mty-stdlib/src/host.rs
+++ b/crates/mty-stdlib/src/host.rs
@@ -36,10 +36,10 @@ pub fn dispatch(path: &[String], method: &str, args: &[Value]) -> Value {
         ("std.time", "now") => time_now(),
         ("std.time", "sleep") => time_sleep(args),
         // -------- fs --------
-        ("std.fs", "read") => fs_read(args),
-        ("std.fs", "write") => fs_write(args),
+        ("std.fs", "read" | "read_file" | "read_to_string") => fs_read(args),
+        ("std.fs", "write" | "write_file" | "write_string") => fs_write(args),
         ("std.fs", "exists") => fs_exists(args),
-        ("std.fs", "list_dir") => fs_list_dir(args),
+        ("std.fs", "list_dir" | "read_dir") => fs_list_dir(args),
         // -------- http (sync wrapper around tokio runtime) --------
         ("std.http", "get") => http_get(args),
         ("std.http", "post") => http_post(args),
@@ -268,5 +268,45 @@ fn http_post(args: &[Value]) -> Value {
     match rt.block_on(crate::http::post(&url, body)) {
         Ok(resp) => Value::Str(resp.body_str().to_string()),
         Err(_) => Value::Unit,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fs_host_dispatch_accepts_agent_friendly_aliases() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("notes").join("one.txt");
+        let path = path.display().to_string();
+
+        let write = dispatch(
+            &["std".into(), "fs".into()],
+            "write_file",
+            &[Value::Str(path.clone()), Value::Str("hello".into())],
+        );
+        assert!(matches!(write, Value::Unit));
+
+        let read = dispatch(
+            &["std".into(), "fs".into()],
+            "read_to_string",
+            &[Value::Str(path.clone())],
+        );
+        assert!(matches!(read, Value::Str(ref value) if value == "hello"));
+
+        let exists = dispatch(
+            &["std".into(), "fs".into()],
+            "exists",
+            &[Value::Str(path.clone())],
+        );
+        assert!(matches!(exists, Value::Bool(true)));
+
+        let listing = dispatch(
+            &["std".into(), "fs".into()],
+            "read_dir",
+            &[Value::Str(dir.path().join("notes").display().to_string())],
+        );
+        assert!(matches!(listing, Value::Array(entries) if entries.len() == 1));
     }
 }

--- a/dev/history/README.md
+++ b/dev/history/README.md
@@ -55,8 +55,9 @@ and later (the track-driven era) consult the individual
 - v0.43 draft — IDE dogfooding correctness rollup: short-circuit lowering,
   interpreter mutator writeback, top-level `const` formatting, prefix-call
   parsing, and native link diagnostics
-- v0.44 draft — public Mighty milestone versioning plus parser resilience for
-  long agent-generated `else if` command ladders
+- v0.44 draft — public Mighty milestone versioning, parser resilience for
+  long agent-generated `else if` command ladders, and default `mty run`
+  fallback for host-backed `std.fs` calls
 
 | File | Headline |
 |---|---|

--- a/dev/history/releases/RELEASE-v0.44.md
+++ b/dev/history/releases/RELEASE-v0.44.md
@@ -25,6 +25,12 @@ versions, silent defaults, or process-level stack overflows.
   nested `IF_EXPR` CST shape. A 512-arm ladder now passes parser
   regression coverage and `mty check`, removing the practical ceiling
   hit by Mighty IDE key/command dispatch growth.
+- **L18:** host-backed `std.fs` calls now force the default `mty run`
+  path onto the interpreter fallback instead of compiling through the
+  Cranelift generic extern stub. The host dispatcher accepts
+  agent-friendly aliases (`read_file`, `read_to_string`, `write_file`,
+  `write_string`, and `read_dir`) so generated app code and docs can
+  use the common file-operation names directly.
 
 ## Validation plan
 
@@ -39,8 +45,8 @@ versions, silent defaults, or process-level stack overflows.
 
 ## Carry-forward priorities
 
-- **L18 (P1):** expose `std.fs` as a Mighty-callable capability API so
-  built Mighty apps can save/load without a Rust shim owning file I/O.
+- Continue expanding `std.fs` from interpreter-hosted calls toward a
+  fully native capability ABI for AOT/JIT output.
 - Broaden formatter rollout beyond safe top-level item shapes.
 - Continue replacing scalar ABI pain points with structured result and
   command surfaces that agents can generate without manual id mirrors.

--- a/docs/reference/cli/mty-run.md
+++ b/docs/reference/cli/mty-run.md
@@ -2,8 +2,8 @@
 
 Compile a Mighty source file and execute it.
 
-**Slice 7 (`v0.7.0-runtime`):** `mty run` now defaults to the
-slice-7 runtime — a tokio-backed concurrent executor with mailboxes,
+**Slice 7 (`v0.7.0-runtime`):** `mty run` defaults to the slice-7
+runtime, a tokio-backed concurrent executor with mailboxes,
 supervisors, deadline timers, and budget/sandbox enforcement. Pass
 `--legacy-interp` to fall back to the slice-6 synchronous interpreter
 for diagnostic comparison.
@@ -27,29 +27,27 @@ executing:
 3. Effect inference + capability subsumption
 4. Borrow check
 5. MtyIR lowering
-6. **Runtime execution** (slice 7): build a `Runtime`, run `main` on
-   the slice-6 evaluator inside `tokio::block_on`; any agents spawned
-   during `main` use the runtime's per-agent task loops. Long-running
-   services that want explicit shutdown control should instead embed
-   via the programmatic `sdust_runtime::Runtime` API.
+6. Runtime execution: build a `Runtime`, run `main` on the evaluator
+   inside `tokio::block_on`, and run spawned agents on the runtime's
+   per-agent task loops.
 
-If any earlier stage reports an *error*, `mty run` prints the
-diagnostics (Ariadne-style with source spans) and exits **1**.
+If any earlier stage reports an error, `mty run` prints diagnostics
+with source spans and exits 1.
 
-Otherwise the interpreter starts at the fn named `main`. Slice 6/7's
-`main` takes zero arguments and may return:
+Otherwise execution starts at the fn named `main`. `main` takes zero
+arguments today and may return:
 
-- `()` / `Unit` — exit 0
-- `I32` (or another integer) — that value as the exit code
-- `Result::Ok(...)` — exit 0
-- `Result::Err(...)` — exit 1 (printed err payload)
+- `()` / `Unit` - exit 0
+- `I32` or another integer - that value as the exit code
+- `Result::Ok(...)` - exit 0
+- `Result::Err(...)` - exit 1, with the err payload printed
 
-A runtime trap (`panic(msg)`, divide-by-zero, missing handler, …)
-prints `trap SD5xxx: message` to stderr and exits **1**.
+A runtime trap (`panic(msg)`, divide-by-zero, missing handler, and so
+on) prints `trap SD5xxx: message` to stderr and exits 1.
 
-If the program has no `fn main`, `mty run` returns the runtime to
-shut down all agents and exits **0** (this matches example 07/08/10
-which lack a `main` in their canonical form).
+If the program has no `fn main`, `mty run` returns the runtime to shut
+down all agents and exits 0. This matches examples 07, 08, and 10,
+which lack a `main` in their canonical form.
 
 ## Exit codes
 
@@ -67,13 +65,14 @@ which lack a `main` in their canonical form).
 | `MTY_TRACE=stderr`        | emit JSON telemetry lines to stderr    |
 | `MTY_TRACE=file:/path`    | append JSON telemetry to file          |
 | `MTY_RUNTIME_THREADS=N`   | tokio worker thread count (default 1)  |
-| `MTY_DET_SEED=N`          | (reserved) seed for deterministic mode |
-| `MTY_HTTP_MOCK=1`         | (reserved) skip TCP bind for tests     |
+| `MTY_DET_SEED=N`          | reserved seed for deterministic mode   |
+| `MTY_HTTP_MOCK=1`         | reserved skip-TCP-bind flag for tests  |
 
 The legacy `STARDUST_*` spellings (`STARDUST_TRACE`,
-`STARDUST_RUNTIME_THREADS`, …) are still honoured for back-compat
-with v0.6-era deployments; the first lookup that falls through to
-a `STARDUST_*` name emits a one-shot deprecation warning on stderr.
+`STARDUST_RUNTIME_THREADS`, and so on) are still honoured for
+back-compat with v0.6-era deployments; the first lookup that falls
+through to a `STARDUST_*` name emits a one-shot deprecation warning on
+stderr.
 
 ## Example
 
@@ -108,26 +107,25 @@ hi
 
 ## Effect handling
 
-Effect calls (`fs.read`, `net.get`, …) are routed through the
-runtime's `StdHost`. Slice 7's host honours sandbox allowlists when
-they are set on the active budget (host:port for `net.*`, prefix
-match for `fs.*`) but does not yet perform real I/O — the call
-returns `Unit` after the check. Real I/O wires in slice 8 along with
-the codegen.
+Effect calls (`std.fs.read`, `std.fs.write`, `std.fs.exists`,
+`std.fs.list_dir`, and their documented aliases) are routed through
+the runtime's host dispatcher. If the native Cranelift path reaches a
+host-backed filesystem call, `mty run` falls back to the interpreter
+so the operation uses the same capability checks and real file I/O as
+`--legacy-interp`.
 
 ## Related commands
 
-- `mty check <file>` — parse + lower + type-check without executing
-- `mty dump --sir <file>` — print the MtyIR program
-- `mty dump --hir <file>` — print the lowered HIR
-- `mty dump --ast <file>` — print the AST item summary
-- `mty explain SD5xxx` — explain a runtime diagnostic
+- `mty check <file>` - parse + lower + type-check without executing
+- `mty dump --sir <file>` - print the MtyIR program
+- `mty dump --hir <file>` - print the lowered HIR
+- `mty dump --ast <file>` - print the AST item summary
+- `mty explain SD5xxx` - explain a runtime diagnostic
 
-## Future work (slice 8+)
+## Future work
 
 - Forward command-line args to `main(args: &[Str])`
 - Honour environment variables when the program reads `std.env`
-- Wire automatic supervisor restart (the policy is in place; the
-  orchestrator lands with codegen)
-- Real arena allocator (replaces the slice-7 approximate mem budget)
-- Native + Wasm codegen via LLVM / Cranelift
+- Wire automatic supervisor restart; the policy is in place, and the
+  orchestrator lands with codegen
+- Native capability ABI for host-backed stdlib calls in JIT/AOT output

--- a/docs/reference/stdlib/fs.md
+++ b/docs/reference/stdlib/fs.md
@@ -11,6 +11,14 @@ fn exists(fs: Fs, path: Path) -> Bool
 fn list_dir(fs: Fs, path: Path) -> Vec[Path]!IoErr
 ```
 
+The interpreter-backed host dispatcher also accepts the agent-friendly
+aliases `read_file`, `read_to_string`, `write_file`, `write_string`,
+and `read_dir`. Those names map to the same capability checks as the
+canonical operations above. When default `mty run` sees one of these
+host-backed calls in the Cranelift path, it falls back to interpreter
+execution so app code gets real file I/O instead of the native extern
+placeholder.
+
 In Rust:
 
 ```rust


### PR DESCRIPTION
## Summary
- make Cranelift report host-backed `std.fs` calls as unsupported so default `mty run` falls back to the interpreter instead of the native extern placeholder
- add agent-friendly `std.fs` dispatcher aliases: `read_file`, `read_to_string`, `write_file`, `write_string`, and `read_dir`
- update v0.44 changelog, release notes, README, and reference docs for the filesystem fallback behavior

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p mty-driver jit_run_interpreter_hosted_std_fs_returns_fallback_signal`
- `cargo test -p mty-stdlib fs_host_dispatch_accepts_agent_friendly_aliases`
- `cargo clippy -p mty-codegen-cranelift -p mty-driver -p mty-stdlib --all-targets -- -D warnings`
- manual default `target\\debug\\mty.exe run C:\\tmp\\mty-fs-smoke\\main.mty` writes and reads `hello`

Note: local HTTPS `git push` repeatedly hung in this environment, so this branch was published through the GitHub API with the same tree as the validated local commit.