### PR TITLE
docs: open v0.45 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,18 @@ For the full per-release notes, see
 
 ## [Unreleased]
 
-v0.44 development focuses on removing the remaining IDE-dogfooding
-trust gaps that make agent-built apps harder to diagnose.
+v0.45 development focuses on making agent-authored apps easier to
+ship: native capability ABI coverage, broader formatter rollout, and
+structured command/result surfaces that reduce shim code.
+
+## [0.44.0] - 2026-06-01
+
+v0.44 removed release-identity and IDE-dogfooding trust gaps that make
+agent-built apps harder to diagnose.
 
 ### Fixed
 - **L9:** `mty --version` now reports the Mighty language/toolchain
-  milestone (`0.44.0-dev` on main) instead of the internal Rust crate
+  milestone (`0.44.0`) instead of the internal Rust crate
   version `0.1.0`. The agent HTTP `/v1/agent/version` endpoint uses
   the same public version source.
 - **L37:** long top-level `else if` ladders now parse without growing
@@ -30,6 +36,7 @@ trust gaps that make agent-built apps harder to diagnose.
   agent spellings (`read_file`, `read_to_string`, `write_file`,
   `write_string`, and `read_dir`) alongside the existing `std.fs`
   names.
+[Release notes](dev/history/releases/RELEASE-v0.44.md).
 
 ## [0.43.0] - 2026-05-31
 
@@ -2531,7 +2538,8 @@ new` / `check` / `fmt` / `dump` / `run` / `build` / `explain`. 65+
 diagnostic codes across MT0xxx..MT8xxx. MSRV Rust 1.85. **376 tests
 passing.** [Release notes](dev/history/releases/RELEASE-v0.1.md).
 
-[Unreleased]: https://github.com/hassard0/Mighty/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/hassard0/Mighty/compare/v0.44.0...HEAD
+[0.44.0]: https://github.com/hassard0/Mighty/releases/tag/v0.44.0
 [0.11.0]: https://github.com/hassard0/Mighty/releases/tag/v0.11.0
 [0.10.0]: https://github.com/hassard0/Mighty/releases/tag/v0.10.0
 [0.9.0]: https://github.com/hassard0/Mighty/releases/tag/v0.9.0

--- a/README.md
+++ b/README.md
@@ -14,22 +14,19 @@
 
 Compiler, runtime, formatter, package manager, doc generator, LSP,
 and stdlib all live in one Rust workspace and one `mty` binary.
-v0.43 is the current release: the Mighty IDE is itself written in
+v0.44 is the current release: the Mighty IDE is itself written in
 Mighty, and every bug it surfaces lands as a release-gate fix in the
-next cycle. v0.43 is the IDE-dogfooding correctness rollup for
-short-circuit `&&`/`||` lowering, interpreter writeback for
-statement-form `Vec`/`String` mutators (`v.push(x)`, `v.pop()`,
-`v.clear()`), syntax-aware top-level `const` formatting, prefix-call
-parsing (`!pred(x)`), truthful native-link diagnostics after object
-emission, LSP document symbols, and Windows control pipes.
+next cycle. v0.44 makes dev builds identify as the public Mighty
+milestone, parses long agent-generated `else if` command routers
+iteratively, and makes default `mty run` fall back to the interpreter
+for host-backed `std.fs` calls instead of routing them through the
+native extern stub.
 
-`main` is now the v0.44 development line; dev builds report
-`mty 0.44.0-dev` so bug reports and agent telemetry point at the
-Mighty milestone rather than the internal Rust crate version. v0.44 is
-also hardening agent-generated app shapes: long `else if` command
-routers now parse iteratively, and default `mty run` falls back to the
-interpreter for host-backed `std.fs` calls instead of routing them
-through the native extern stub.
+`main` is now the v0.45 development line; dev builds report
+`mty 0.45.0-dev`. The v0.45 focus is turning more interpreter-hosted
+stdlib behavior into native capability ABI coverage, broadening the
+safe formatter rollout, and replacing shim-heavy scalar command
+surfaces with structured result shapes agents can generate directly.
 
 ## Why Mighty
 

--- a/crates/mty-cli/src/lib.rs
+++ b/crates/mty-cli/src/lib.rs
@@ -22,9 +22,9 @@ pub mod cmd;
 ///
 /// The Rust workspace crates intentionally keep their internal crate
 /// version while the public toolchain advances by Mighty milestones
-/// (`v0.43.0`, `v0.44.0-dev`, ...). Keep this aligned with
+/// (`v0.44.0`, `v0.45.0-dev`, ...). Keep this aligned with
 /// `CHANGELOG.md` and release tags.
-pub const MIGHTY_VERSION: &str = "0.44.0-dev";
+pub const MIGHTY_VERSION: &str = "0.45.0-dev";
 
 // v0.35 T1 — browser playground exports. `wasm-pack build --target web`
 // reads this cdylib's `#[wasm_bindgen]` symbols (`init` / `check` /

--- a/dev/history/README.md
+++ b/dev/history/README.md
@@ -52,12 +52,14 @@ and later (the track-driven era) consult the individual
   `cli-min` install + macOS PGO re-enabled
 - v0.42 — Mighty IDE blocker closure: numeric casts, parser diagnostics,
   native computed `log()`, formatter safety, and Vec-liveness regression locks
-- v0.43 draft — IDE dogfooding correctness rollup: short-circuit lowering,
+- v0.43 — IDE dogfooding correctness rollup: short-circuit lowering,
   interpreter mutator writeback, top-level `const` formatting, prefix-call
   parsing, and native link diagnostics
-- v0.44 draft — public Mighty milestone versioning, parser resilience for
+- v0.44 — public Mighty milestone versioning, parser resilience for
   long agent-generated `else if` command ladders, and default `mty run`
   fallback for host-backed `std.fs` calls
+- v0.45 draft — native capability ABI coverage, broader formatter rollout,
+  and structured command/result surfaces for agent-built apps
 
 | File | Headline |
 |---|---|

--- a/dev/history/releases/RELEASE-v0.44.md
+++ b/dev/history/releases/RELEASE-v0.44.md
@@ -1,8 +1,8 @@
-# Mighty v0.44 - Draft Release Notes
+# Mighty v0.44 Release Notes
 
 **Tag:** `v0.44.0`
-**Date:** TBD
-**Status:** DRAFT - agentic app reliability and release identity.
+**Date:** 2026-06-01
+**Status:** SHIPPED - agentic app reliability and release identity.
 
 **Headline:** make Mighty easier for agents to build and debug by
 closing trust gaps surfaced by Mighty IDE dogfooding.
@@ -15,10 +15,10 @@ agent-authored command routers. The theme for this release is simple:
 generated app code should fail with useful diagnostics, not with stale
 versions, silent defaults, or process-level stack overflows.
 
-## Release candidates
+## Shipped
 
 - **L9:** `mty --version` reports the Mighty language/toolchain
-  milestone (`0.44.0-dev` on main) instead of the internal Rust crate
+  milestone (`0.44.0`) instead of the internal Rust crate
   version `0.1.0`. The agent HTTP `/v1/agent/version` endpoint uses
   the same public version source.
 - **L37:** `else if` ladders parse iteratively while preserving the
@@ -32,16 +32,15 @@ versions, silent defaults, or process-level stack overflows.
   `write_string`, and `read_dir`) so generated app code and docs can
   use the common file-operation names directly.
 
-## Validation plan
+## Validation
 
-- Keep the full CI matrix green before tagging: Ubuntu, macOS,
-  Windows, minimal features, strict clippy, MSRV, build smoke,
-  `mty-bench`, and `cargo audit`.
-- Run focused parser, CLI, and driver checks for every IDE-dogfooding
-  fix included in the release.
-- Keep `main` protected. Use admin merge only to move green PRs through
-  branch rules; do not weaken checks, force-push protection, or delete
-  protection.
+- PR #18, #19, and #20 passed their required checks before merge.
+- Main CI passed after rerunning two infrastructure-failed jobs that
+  hit GitHub runner disk exhaustion.
+- The `v0.44.0` Release workflow completed successfully and published
+  platform binaries plus the conformance kit.
+- `main` stayed protected; admin merge was used only to move green PRs
+  through branch rules.
 
 ## Carry-forward priorities
 

--- a/dev/history/releases/RELEASE-v0.45.md
+++ b/dev/history/releases/RELEASE-v0.45.md
@@ -1,0 +1,37 @@
+# Mighty v0.45 - Draft Release Notes
+
+**Tag:** `v0.45.0`
+**Date:** TBD
+**Status:** DRAFT - agent-built app shipping ergonomics.
+
+**Headline:** reduce the remaining shim code agents need when building
+real apps in Mighty.
+
+## Direction
+
+v0.45 picks up the carry-forward work from v0.44: make host-backed
+stdlib behavior available through native capability ABI paths, continue
+the formatter rollout without destructive rewrites, and replace
+stringly/scalar command plumbing with structured result surfaces that
+agents can inspect, test, and regenerate safely.
+
+## Candidate tracks
+
+- **Native capability ABI:** move `std.fs` beyond interpreter fallback
+  for JIT/AOT output while preserving capability checks and clear
+  diagnostics.
+- **Formatter rollout:** expand syntax-aware formatting from safe
+  top-level `const` items into more item kinds with regression tests
+  for comments and whitespace preservation.
+- **Agent command surfaces:** prefer structured result values over
+  sentinel strings and mirrored IDs in CLI, LSP, and runtime control
+  paths.
+- **Release hygiene:** keep README, changelog, release notes, and
+  `mty --version` aligned before every tag.
+
+## Validation plan
+
+- Keep full CI green before every release tag.
+- Add focused smoke tests for each native capability ABI expansion.
+- Keep Mighty IDE lessons as the priority source for release-gate
+  fixes.


### PR DESCRIPTION
## Summary
- mark v0.44.0 as shipped in changelog/history and add the v0.45 draft notes
- bump the public Mighty toolchain version to 0.45.0-dev
- update README so the current release is v0.44 and main is the v0.45 development line

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p mty-cli --lib
- cargo run -p mty-cli -- --version