### PR TITLE
v0.45: mty check --json structured result document

### DIFF
--- a/crates/mty-cli/src/cmd/agent.rs
+++ b/crates/mty-cli/src/cmd/agent.rs
@@ -28,7 +28,7 @@ use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 
 use mty_diagnostics::diagnostic::Diagnostic;
-use mty_diagnostics::fix::{to_ndjson, DiagnosticEnvelope, ToEnvelope};
+use mty_diagnostics::fix::{build_check_result, to_ndjson, DiagnosticEnvelope, ToEnvelope};
 use mty_diagnostics::{codes, Severity};
 use mty_driver::{lower, parse_source, type_and_borrow_check};
 use serde::{Deserialize, Serialize};
@@ -400,6 +400,14 @@ impl Session {
             emit(out, &Response::Envelope(Box::new(EnvelopeMsg { env })));
         }
 
+        // v0.45 T3 — structured-result document piggybacks on every
+        // `check` response under the `result` extra field. Mirrors the
+        // shape `mty check --json` emits and lets agents stop
+        // line-by-line envelope-stitching when they only need the
+        // flat code+span+message tuple.
+        let check_result = build_check_result(&diags, &path_buf.display().to_string(), &src);
+        let result_value = serde_json::to_value(&check_result).expect("check result serializes");
+
         self.last_path = Some(path_buf);
         self.last_source = Some(src);
         self.last_envelopes = envelopes;
@@ -410,6 +418,7 @@ impl Session {
             JsonValue::from(diags.len() as u64),
         );
         extra.insert("fix_count".into(), JsonValue::from(fix_count as u64));
+        extra.insert("result".into(), result_value);
         emit(
             out,
             &Response::Result(ResultMsg {

--- a/crates/mty-cli/src/cmd/check.rs
+++ b/crates/mty-cli/src/cmd/check.rs
@@ -1,4 +1,4 @@
-use mty_diagnostics::fix::to_ndjson;
+use mty_diagnostics::fix::{to_check_result_json, to_ndjson};
 use mty_diagnostics::render::ariadne::render_all;
 use mty_diagnostics::Severity;
 use mty_driver::{
@@ -10,26 +10,48 @@ use std::path::Path;
 
 /// Output mode for `mty check`.
 ///
-/// v0.33 T4 adds the `Json` route: instead of the pretty
-/// human-readable report, each diagnostic is emitted as one JSON line
-/// (NDJSON) on stdout, conforming to the agent-mode envelope schema
-/// documented at `docs/internals/diagnostic-envelopes.md`. With
-/// `include_source = true` (`--include-source`) each envelope also
-/// carries a 3-line source snippet around the primary span so an
-/// agent can render the location without re-reading the file.
+/// v0.33 T4 added the NDJSON envelope route (`--format json`).
+/// v0.45 T3 adds the single-document structured-result route
+/// (`--json`, exposed via [`CheckFormat::ResultJson`]):
+///
+/// * `Pretty` — ariadne colored report on stderr (default).
+/// * `Json` — NDJSON envelopes on stdout (one per diagnostic).
+///   Used by `mty fix --apply --from-stdin` and the agent protocol.
+/// * `ResultJson` — single JSON document on stdout. Same fields
+///   every other v0.45 agent surface (LSP, runtime control paths)
+///   is migrating to: `{ok, path, diagnostics: [{code, severity,
+///   message, span}]}`. See `docs/internals/check-result-json.md`.
 #[derive(Debug, Clone, Copy)]
 pub enum CheckFormat {
     /// Default — `ariadne` colored report on stderr.
     Pretty,
     /// One JSON envelope per diagnostic, NDJSON-style, on stdout.
     Json,
+    /// v0.45 T3 — single JSON document on stdout with a flat
+    /// `{ok, path, diagnostics}` shape.
+    ResultJson,
 }
 
 impl CheckFormat {
     pub fn parse(s: &str) -> CheckFormat {
         match s {
             "json" => CheckFormat::Json,
+            // v0.45 T3: accept both `--format=json-result` and the
+            // shorter `--format=result`. The flag-driven path uses
+            // `--json` which lands here through `from_json_flag`.
+            "json-result" | "result" => CheckFormat::ResultJson,
             _ => CheckFormat::Pretty,
+        }
+    }
+
+    /// v0.45 T3 — pick the format from the boolean `--json` flag.
+    /// True picks the single-document structured-result route;
+    /// false leaves the caller's choice (`--format`) untouched.
+    pub fn from_json_flag(json: bool, base: CheckFormat) -> CheckFormat {
+        if json {
+            CheckFormat::ResultJson
+        } else {
+            base
         }
     }
 }
@@ -115,6 +137,19 @@ pub fn run_with(path: &Path, format: CheckFormat, include_source: bool) -> i32 {
                 return 1;
             }
             // No "ok:" line under JSON mode — clean = zero output.
+        }
+        CheckFormat::ResultJson => {
+            // v0.45 T3 — single JSON document on stdout. Always
+            // emitted (even on success) so the agent gets a
+            // deterministic "ok:true, diagnostics:[]" handshake
+            // it can `serde_json::from_str` without checking
+            // whether stdout was empty. NO ariadne text — clean
+            // parseable output only.
+            let doc = to_check_result_json(&diags, &path.display().to_string(), &src);
+            print!("{}", doc);
+            if has_error {
+                return 1;
+            }
         }
     }
     0

--- a/crates/mty-cli/src/main.rs
+++ b/crates/mty-cli/src/main.rs
@@ -87,15 +87,28 @@ enum Cmd {
     /// `--include-source` to embed a 3-line source snippet in every
     /// envelope. The default `pretty` output (ariadne-rendered) is
     /// unchanged from previous releases.
+    ///
+    /// v0.45 T3 — `--json` emits a single structured-result document
+    /// on stdout (`{ok, path, diagnostics:[{code, severity, message,
+    /// span}]}`) and suppresses every ariadne byte. This is the
+    /// "agent command surfaces" shape every other v0.45 surface (LSP,
+    /// runtime control paths) is migrating to. The NDJSON envelope
+    /// path (`--format json`) is unchanged for existing consumers
+    /// like `mty fix --apply --from-stdin`.
     Check {
         path: std::path::PathBuf,
-        /// `pretty` (default) or `json`.
+        /// `pretty` (default), `json` (NDJSON envelopes), or
+        /// `json-result` (single structured-result document).
         #[arg(long, default_value = "pretty")]
         format: String,
         /// Only meaningful with `--format json`: embed a 3-line source
         /// snippet around each diagnostic's primary span.
         #[arg(long)]
         include_source: bool,
+        /// v0.45 T3 — emit a single structured-result JSON document
+        /// on stdout (no ariadne text). Wins over `--format` when set.
+        #[arg(long)]
+        json: bool,
     },
     /// Dump intermediate representations.
     Dump {
@@ -604,8 +617,10 @@ fn run_cli(cli: Cli) -> i32 {
             path,
             format,
             include_source,
+            json,
         } => {
-            let fmt = cmd::check::CheckFormat::parse(&format);
+            let base = cmd::check::CheckFormat::parse(&format);
+            let fmt = cmd::check::CheckFormat::from_json_flag(json, base);
             cmd::check::run_with(&path, fmt, include_source)
         }
         Cmd::Dump {

--- a/crates/mty-cli/tests/agent_mode.rs
+++ b/crates/mty-cli/tests/agent_mode.rs
@@ -242,6 +242,65 @@ fn single_shot_check_with_diagnostic_streams_envelope() {
     assert!(results[0]["diagnostics_count"].as_u64().unwrap_or(0) >= 1);
 }
 
+/// v0.45 T3 — the `check` op `result` line now carries a
+/// structured-result document under `result.*` matching `mty check
+/// --json`'s wire shape. Mirrors the migration spelled out in the
+/// v0.45 "agent command surfaces" track.
+#[test]
+fn single_shot_check_carries_structured_result_v45t3() {
+    let (_tmp, p) = write_tmp("bad.mty", "fn main() -> Unit {\n  let x = (\n}\n");
+    let req = format!(r#"{{"op":"check","path":"{}"}}"#, path_json(&p));
+    let (_code, lines, _) = single_shot(&req);
+    let results = find_kind(&lines, "result");
+    assert_eq!(results.len(), 1);
+    let r = &results[0];
+    assert_eq!(r["op"], "check");
+    // Structured result document piggybacks under `result`.
+    let result = &r["result"];
+    assert!(
+        result.is_object(),
+        "expected result.result object, got: {r}"
+    );
+    assert_eq!(result["ok"], false);
+    assert_eq!(
+        result["path"].as_str().unwrap_or(""),
+        p.display().to_string()
+    );
+    let diags = result["diagnostics"]
+        .as_array()
+        .expect("result.diagnostics array");
+    assert!(!diags.is_empty(), "expected ≥1 diagnostic, got: {result}");
+    let first = &diags[0];
+    // Each entry has code/severity/message/span(line,col,end_line,end_col).
+    assert!(first["code"].as_str().unwrap_or("").starts_with("MT"));
+    assert!(matches!(
+        first["severity"].as_str().unwrap_or(""),
+        "error" | "warning" | "note" | "help"
+    ));
+    assert!(first["message"].is_string());
+    let span = &first["span"];
+    assert!(span["line"].is_u64());
+    assert!(span["col"].is_u64());
+    assert!(span["end_line"].is_u64());
+    assert!(span["end_col"].is_u64());
+}
+
+/// v0.45 T3 — clean file under the agent `check` op also gets a
+/// structured-result document; consumers can stop checking
+/// `diagnostics_count == 0` and look directly at `result.ok`.
+#[test]
+fn single_shot_check_clean_carries_structured_result_v45t3() {
+    let (_tmp, p) = write_tmp("ok.mty", "fn main() -> Unit { }\n");
+    let req = format!(r#"{{"op":"check","path":"{}"}}"#, path_json(&p));
+    let (_code, lines, _) = single_shot(&req);
+    let results = find_kind(&lines, "result");
+    assert_eq!(results.len(), 1);
+    let result = &results[0]["result"];
+    assert!(result.is_object());
+    assert_eq!(result["ok"], true);
+    assert!(result["diagnostics"].as_array().unwrap().is_empty());
+}
+
 #[test]
 fn single_shot_check_include_source_embeds_snippet() {
     let (_tmp, p) = write_tmp("bad.mty", "fn main() -> Unit {\n  let x = (\n}\n");

--- a/crates/mty-cli/tests/cmd_check_json.rs
+++ b/crates/mty-cli/tests/cmd_check_json.rs
@@ -1,0 +1,257 @@
+#![cfg(feature = "host-toolchain")]
+//! v0.45 T3 — end-to-end tests for `mty check --json`, the new
+//! structured-result document surface.
+//!
+//! The flag emits ONE JSON document on stdout (not NDJSON, not pretty
+//! text) with the shape:
+//!
+//! ```json
+//! {
+//!   "ok": false,
+//!   "path": "...",
+//!   "diagnostics": [
+//!     {
+//!       "code": "MT2001",
+//!       "severity": "error",
+//!       "message": "...",
+//!       "span": {"file":"...","line":N,"col":N,"end_line":N,"end_col":N}
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! Covered:
+//!
+//! 1. Clean file → `{ok:true, diagnostics:[]}`, exit 0, no ariadne bytes.
+//! 2. File with two type errors → 2 distinct line:col diagnostics, exit 1.
+//! 3. File referencing an undefined name → MT2021, exit 1.
+//! 4. File with a parse glitch → MT0xxx, exit 1.
+//! 5. Back-compat: without `--json`, ariadne pretty output is unchanged.
+//!
+//! T6 covers (1) (3) (4) (5) for the pretty path; this file mirrors
+//! the four cases under `--json`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn mty_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mty")
+}
+
+fn write_tempfile(name: &str, src: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "mty_check_v45t3_{}_{}.mty",
+        std::process::id(),
+        name
+    ));
+    std::fs::write(&p, src).expect("write temp .mty");
+    p
+}
+
+/// Spawn `mty check --json <path>`. Returns `(exit_code, stdout, stderr)`.
+fn run_check_json(path: &PathBuf) -> (i32, String, String) {
+    let mut cmd = Command::new(mty_bin());
+    cmd.arg("check").arg("--json").arg(path);
+    cmd.env("NO_COLOR", "1"); // Belt-and-braces — JSON path emits no ANSI anyway.
+    let out = cmd.output().expect("spawn mty check --json");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// Spawn `mty check <path>` (no `--json`) so we can confirm the
+/// ariadne pretty path is unchanged.
+fn run_check_pretty(path: &PathBuf) -> (i32, String, String) {
+    let mut cmd = Command::new(mty_bin());
+    cmd.arg("check").arg(path);
+    cmd.env("NO_COLOR", "1");
+    let out = cmd.output().expect("spawn mty check");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+// ---- (1) clean file ----
+
+#[test]
+fn json_clean_file_is_ok_zero_exit() {
+    let path = write_tempfile("clean", "fn demo() {\n    log(\"hi\");\n}\n");
+    let (code, out, err) = run_check_json(&path);
+    assert_eq!(code, 0, "clean file should exit 0. stderr: {err}");
+    // No ariadne text on stderr — clean parseable output only.
+    assert!(
+        !err.contains('\x1b'),
+        "no ANSI escapes expected under --json. stderr: {err:?}"
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("not JSON: {e}; stdout: {out}"));
+    assert_eq!(doc["ok"], true);
+    assert_eq!(doc["path"].as_str().unwrap(), path.display().to_string());
+    assert!(doc["diagnostics"].as_array().unwrap().is_empty());
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---- (2) two type errors, distinct line:col ----
+
+#[test]
+fn json_two_type_errors_distinct_positions() {
+    let path = write_tempfile(
+        "two_errs",
+        "fn demo() {\n    let x: I32 = \"hello\";\n    let y: Str = 42;\n}\n",
+    );
+    let (code, out, err) = run_check_json(&path);
+    assert_eq!(code, 1, "two type errors should exit 1. stderr: {err}");
+    let doc: serde_json::Value =
+        serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("not JSON: {e}; stdout: {out}"));
+    assert_eq!(doc["ok"], false);
+    let diags = doc["diagnostics"].as_array().expect("diagnostics array");
+    assert!(
+        diags.len() >= 2,
+        "expected ≥2 diagnostics, got {}: {out}",
+        diags.len()
+    );
+    // The two type errors must report DIFFERENT (line, col) — not both
+    // collapsed onto the fn header.
+    let mut positions: Vec<(u64, u64)> = diags
+        .iter()
+        .filter(|d| d["severity"] == "error")
+        .map(|d| {
+            (
+                d["span"]["line"].as_u64().unwrap(),
+                d["span"]["col"].as_u64().unwrap(),
+            )
+        })
+        .collect();
+    positions.sort();
+    positions.dedup();
+    assert!(
+        positions.len() >= 2,
+        "expected ≥2 distinct error positions, got {positions:?} from {out}"
+    );
+    // Spans should include end_line/end_col.
+    for d in diags {
+        let span = &d["span"];
+        assert!(span["line"].is_u64());
+        assert!(span["col"].is_u64());
+        assert!(span["end_line"].is_u64());
+        assert!(span["end_col"].is_u64());
+        assert_eq!(span["file"].as_str().unwrap(), path.display().to_string());
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---- (3) undefined identifier surfaces as MT2021 ----
+
+#[test]
+fn json_undefined_identifier_surfaces_mt2021() {
+    let path = write_tempfile("undef", "fn demo() {\n    log(undefined_thing);\n}\n");
+    let (code, out, err) = run_check_json(&path);
+    assert_eq!(code, 1, "undefined identifier should exit 1. stderr: {err}");
+    let doc: serde_json::Value =
+        serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("not JSON: {e}; stdout: {out}"));
+    assert_eq!(doc["ok"], false);
+    let diags = doc["diagnostics"].as_array().expect("diagnostics array");
+    let mt2021 = diags.iter().find(|d| d["code"] == "MT2021");
+    assert!(
+        mt2021.is_some(),
+        "expected MT2021 in diagnostics; got: {out}"
+    );
+    let dg = mt2021.unwrap();
+    assert_eq!(dg["severity"], "error");
+    assert!(
+        dg["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("undefined_thing"),
+        "expected the offending name in the message, got: {dg}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---- (4) parse glitch surfaces ----
+
+#[test]
+fn json_parse_error_surfaces() {
+    // `let = 42;` — no binding pattern. T6 widened `mty check` to
+    // surface this as MT0001; the --json path inherits the same
+    // diagnostic stream.
+    let path = write_tempfile("parse", "fn demo() {\n    let = 42;\n}\n");
+    let (code, out, err) = run_check_json(&path);
+    assert_eq!(code, 1, "parse error should exit 1. stderr: {err}");
+    let doc: serde_json::Value =
+        serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("not JSON: {e}; stdout: {out}"));
+    assert_eq!(doc["ok"], false);
+    let diags = doc["diagnostics"].as_array().expect("diagnostics array");
+    let parse_diag = diags
+        .iter()
+        .find(|d| d["code"].as_str().unwrap_or("").starts_with("MT00"));
+    assert!(
+        parse_diag.is_some(),
+        "expected a parse-phase MT00xx diagnostic; got: {out}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---- (5) back-compat: pretty path unchanged when `--json` NOT set ----
+
+#[test]
+fn pretty_path_unchanged_without_json_flag() {
+    // Clean file → `ok:` on stdout, exit 0. Matches T6's
+    // `clean_file_still_reports_ok`.
+    let path = write_tempfile("compat_ok", "fn demo() {\n    log(\"hi\");\n}\n");
+    let (code, out, err) = run_check_pretty(&path);
+    assert_eq!(code, 0, "clean file pretty: stderr: {err}");
+    assert!(
+        out.contains("ok:"),
+        "expected `ok:` on stdout under pretty (no --json), got: {out}"
+    );
+    // The pretty path doesn't print the structured-result doc.
+    assert!(!out.trim_start().starts_with('{'));
+    let _ = std::fs::remove_file(&path);
+
+    // Errored file → exit 1, ariadne text on stderr (MT2001 referenced).
+    let path = write_tempfile(
+        "compat_err",
+        "fn demo() {\n    let x: I32 = \"hello\";\n}\n",
+    );
+    let (code, _out, err) = run_check_pretty(&path);
+    assert_eq!(code, 1, "type error pretty: stderr: {err}");
+    assert!(
+        err.contains("MT2"),
+        "expected MT2xxx in stderr under pretty path, got: {err}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---- (6) span carries both start and end ----
+
+#[test]
+fn json_span_carries_start_and_end() {
+    let path = write_tempfile("spans", "fn demo() {\n    let x: I32 = \"hello\";\n}\n");
+    let (_code, out, _err) = run_check_json(&path);
+    let doc: serde_json::Value = serde_json::from_str(out.trim()).expect("JSON");
+    let diags = doc["diagnostics"].as_array().expect("diags");
+    let first = diags
+        .iter()
+        .find(|d| d["severity"] == "error")
+        .expect("at least one error");
+    let span = &first["span"];
+    let line = span["line"].as_u64().unwrap();
+    let col = span["col"].as_u64().unwrap();
+    let end_line = span["end_line"].as_u64().unwrap();
+    let end_col = span["end_col"].as_u64().unwrap();
+    // end >= start in both dimensions.
+    assert!(end_line >= line);
+    if end_line == line {
+        assert!(
+            end_col > col,
+            "end_col must be > col when on the same line; got {end_col} <= {col}"
+        );
+    }
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/mty-diagnostics/src/fix.rs
+++ b/crates/mty-diagnostics/src/fix.rs
@@ -449,6 +449,138 @@ pub fn to_ndjson(
     out
 }
 
+// ---------------------------------------------------------------------------
+// v0.45 T3 — structured `mty check --json` result document
+// ---------------------------------------------------------------------------
+//
+// The pre-existing `--format json` route emits one *envelope* per
+// diagnostic on its own NDJSON line. That shape is rich (it carries
+// fix proposals, prose, see_also, snippet) and has real consumers
+// (`mty fix --apply --from-stdin`, the agent-mode protocol).
+//
+// v0.45 T3 adds a *new*, simpler, single-document shape — the same
+// JSON skeleton CLI/LSP/runtime control paths are migrating to under
+// the v0.45 "agent command surfaces" track:
+//
+// ```json
+// {
+//   "ok": false,
+//   "path": "src/main.mty",
+//   "diagnostics": [
+//     {
+//       "code": "MT2001",
+//       "severity": "error",
+//       "message": "type mismatch: expected Str, found I32",
+//       "span": {
+//         "file": "src/main.mty",
+//         "line": 12, "col": 5,
+//         "end_line": 12, "end_col": 18
+//       }
+//     }
+//   ]
+// }
+// ```
+//
+// Differences from the NDJSON envelope path, intentional:
+//
+// * **Single document, not NDJSON.** Agents that want one
+//   `serde_json::from_str(&stdout)` call get one. NDJSON consumers
+//   keep `--format json`.
+// * **Both start AND end** line/col are exposed. The IDE used to
+//   default `end_col = col + 1`; T3 threads the real end through
+//   when the diagnostic carries an `end > start` byte span, and
+//   falls back to `col + 1` when it doesn't.
+// * **No fix / prose / see_also.** Those stay on the envelope path.
+//   The structured-result shape is the *minimum* every agent
+//   surface in v0.45 agrees on; richer needs continue to flow
+//   through `--format json`.
+
+/// One diagnostic, as the `mty check --json` result shape sees it.
+/// Lean by design: code + severity + message + span.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CheckDiagnostic {
+    pub code: String,
+    pub severity: String,
+    pub message: String,
+    pub span: CheckSpan,
+}
+
+/// 1-indexed span carrying BOTH start and end positions.
+///
+/// Falls back to `end_col = col + 1` when the underlying diagnostic
+/// didn't carry a real end byte offset (matches the IDE's pre-T6
+/// workaround).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CheckSpan {
+    pub file: String,
+    pub line: u32,
+    pub col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+}
+
+/// The whole `mty check --json` document.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CheckResult {
+    /// True iff every diagnostic is below `Error` severity.
+    pub ok: bool,
+    /// The path `mty check` was invoked against (the source-id).
+    pub path: String,
+    /// Every diagnostic emitted, in the order the pipeline produced
+    /// them. Warnings/notes/helps included.
+    pub diagnostics: Vec<CheckDiagnostic>,
+}
+
+/// Build a [`CheckResult`] from a flat diagnostic list + the source
+/// the check ran against.
+///
+/// `path` is used verbatim both as the top-level `path` field and as
+/// each diagnostic's `span.file`, matching the pretty/ariadne path's
+/// "all spans live in the file we just checked" assumption.
+pub fn build_check_result(diags: &[Diagnostic], path: &str, source: &str) -> CheckResult {
+    let mut out = Vec::with_capacity(diags.len());
+    for d in diags {
+        let start = d.primary.start;
+        let end = d.primary.end;
+        let (line, col) = offset_to_line_col(source, start);
+        let (end_line, end_col) = if end > start {
+            offset_to_line_col(source, end)
+        } else {
+            // Fallback matches the IDE's pre-T6 workaround: collapsed
+            // span renders as a single-char highlight.
+            (line, col + 1)
+        };
+        out.push(CheckDiagnostic {
+            code: d.code.as_str(),
+            severity: severity_str(d.severity).to_string(),
+            message: d.primary.message.clone(),
+            span: CheckSpan {
+                file: path.to_string(),
+                line,
+                col,
+                end_line,
+                end_col,
+            },
+        });
+    }
+    let ok = !diags.iter().any(|d| matches!(d.severity, Severity::Error));
+    CheckResult {
+        ok,
+        path: path.to_string(),
+        diagnostics: out,
+    }
+}
+
+/// Serialize a [`CheckResult`] as a single JSON document with a
+/// trailing newline. Used by `mty check --json` and the `mty agent`
+/// `check` op when called with `structured: true`.
+pub fn to_check_result_json(diags: &[Diagnostic], path: &str, source: &str) -> String {
+    let result = build_check_result(diags, path, source);
+    let mut s = serde_json::to_string(&result).expect("check result serializes");
+    s.push('\n');
+    s
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -777,5 +909,142 @@ mod tests {
         let out = to_ndjson(&[d], "x.mty", src, true);
         let env: DiagnosticEnvelope = serde_json::from_str(out.trim_end()).unwrap();
         assert!(env.source.is_some());
+    }
+
+    // ---- v0.45 T3: structured `mty check --json` result document ----
+
+    #[test]
+    fn check_result_clean_file_is_ok() {
+        let result = build_check_result(&[], "src/main.mty", "fn main() {}\n");
+        assert!(result.ok);
+        assert_eq!(result.path, "src/main.mty");
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn check_result_threads_real_end_span() {
+        // `let x: Str = 42;` — point at the `42` literal on line 2.
+        // The diagnostic carries the start AND end byte of the literal.
+        let src = "fn demo() {\n    let x: Str = 42;\n}\n";
+        let start = src.find("42").unwrap();
+        let end = start + 2;
+        let d = Diagnostic::error(
+            DiagCode::new(2001),
+            crate::diagnostic::Label {
+                start,
+                end,
+                message: "type mismatch".into(),
+            },
+        );
+        let r = build_check_result(&[d], "demo.mty", src);
+        assert!(!r.ok);
+        assert_eq!(r.diagnostics.len(), 1);
+        let dg = &r.diagnostics[0];
+        assert_eq!(dg.code, "MT2001");
+        assert_eq!(dg.severity, "error");
+        assert_eq!(dg.span.line, 2);
+        assert_eq!(dg.span.end_line, 2);
+        // end_col MUST be col + 2 (the literal is 2 chars wide).
+        assert_eq!(dg.span.end_col, dg.span.col + 2);
+    }
+
+    #[test]
+    fn check_result_falls_back_to_col_plus_one_when_no_end() {
+        // Diagnostic with start == end (no real range). end_col must
+        // default to col + 1.
+        let d = Diagnostic::error(
+            DiagCode::new(2021),
+            crate::diagnostic::Label {
+                start: 4,
+                end: 4,
+                message: "undefined".into(),
+            },
+        );
+        let r = build_check_result(&[d], "x.mty", "abc\nfoo\n");
+        let dg = &r.diagnostics[0];
+        assert_eq!(dg.span.end_line, dg.span.line);
+        assert_eq!(dg.span.end_col, dg.span.col + 1);
+    }
+
+    #[test]
+    fn check_result_two_errors_distinct_positions() {
+        // Pre-v0.42 T6 both errors would collapse to 1:1. Make sure
+        // T3 surfaces them as two distinct line:col positions.
+        let src = "fn demo() {\n    let x: I32 = \"hello\";\n    let y: Str = 42;\n}\n";
+        let s1 = src.find("\"hello\"").unwrap();
+        let e1 = s1 + "\"hello\"".len();
+        let s2 = src.find("42;").unwrap();
+        let e2 = s2 + 2;
+        let d1 = Diagnostic::error(
+            DiagCode::new(2001),
+            crate::diagnostic::Label {
+                start: s1,
+                end: e1,
+                message: "expected I32, found Str".into(),
+            },
+        );
+        let d2 = Diagnostic::error(
+            DiagCode::new(2001),
+            crate::diagnostic::Label {
+                start: s2,
+                end: e2,
+                message: "expected Str, found I32".into(),
+            },
+        );
+        let r = build_check_result(&[d1, d2], "demo.mty", src);
+        assert!(!r.ok);
+        assert_eq!(r.diagnostics.len(), 2);
+        let (a, b) = (&r.diagnostics[0], &r.diagnostics[1]);
+        assert_eq!(a.span.line, 2);
+        assert_eq!(b.span.line, 3);
+        assert!(
+            a.span.col != b.span.col || a.span.line != b.span.line,
+            "two errors must report distinct line:col"
+        );
+        // Neither anchors at the fn header.
+        for d in &r.diagnostics {
+            assert!(!(d.span.line == 1 && d.span.col == 1));
+        }
+    }
+
+    #[test]
+    fn check_result_json_is_single_document() {
+        let d = Diagnostic::error(
+            DiagCode::new(2001),
+            crate::diagnostic::Label {
+                start: 0,
+                end: 3,
+                message: "boom".into(),
+            },
+        );
+        let out = to_check_result_json(&[d], "x.mty", "abc\n");
+        // Must parse as ONE document, not NDJSON.
+        let parsed: CheckResult = serde_json::from_str(out.trim_end()).expect("single document");
+        assert!(!parsed.ok);
+        assert_eq!(parsed.path, "x.mty");
+        assert_eq!(parsed.diagnostics.len(), 1);
+        // Trailing newline so `tee`/`jq` pipelines stay tidy.
+        assert!(out.ends_with('\n'));
+        // Exactly one newline at the very end — i.e. no NDJSON splits.
+        let nl_count = out.matches('\n').count();
+        assert_eq!(nl_count, 1, "result must be single-line JSON, got: {out}");
+    }
+
+    #[test]
+    fn check_result_only_warnings_is_ok() {
+        // ok is true iff there are no error-severity diagnostics.
+        let mut d = Diagnostic::error(
+            DiagCode::new(2015),
+            crate::diagnostic::Label {
+                start: 0,
+                end: 1,
+                message: "non-exhaustive".into(),
+            },
+        );
+        d.severity = Severity::Warning;
+        let r = build_check_result(&[d], "x.mty", "ab\n");
+        assert!(r.ok, "ok must be true when only warnings are present");
+        assert_eq!(r.diagnostics.len(), 1);
+        assert_eq!(r.diagnostics[0].severity, "warning");
     }
 }

--- a/crates/mty-diagnostics/src/lib.rs
+++ b/crates/mty-diagnostics/src/lib.rs
@@ -9,6 +9,7 @@ pub use apply::{apply_unified_diff, try_apply_alternatives};
 pub use codes::DiagCode;
 pub use diagnostic::{Diagnostic, Label, Severity};
 pub use fix::{
-    snippet_around, span_info_from, to_ndjson, DiagnosticEnvelope, Fix, FixAlternative, FixBuilder,
+    build_check_result, snippet_around, span_info_from, to_check_result_json, to_ndjson,
+    CheckDiagnostic, CheckResult, CheckSpan, DiagnosticEnvelope, Fix, FixAlternative, FixBuilder,
     FixKind, SourceSnippet, SpanInfo, ToEnvelope,
 };

--- a/docs/reference/cli/mty-check.md
+++ b/docs/reference/cli/mty-check.md
@@ -20,6 +20,9 @@ mty check <PATH>
 | Flag | Purpose |
 |---|---|
 | `-h`, `--help` | Print help. |
+| `--format <kind>` | `pretty` (default), `json` (NDJSON envelopes), or `json-result` (single structured-result document). |
+| `--include-source` | Only meaningful with `--format json`: embed a 3-line snippet around each diagnostic's span in every envelope. |
+| `--json` | v0.45 T3 — emit a single structured-result JSON document on stdout (`{ok, path, diagnostics:[{code, severity, message, span:{file, line, col, end_line, end_col}}]}`) and suppress every ariadne byte. Equivalent to `--format json-result`. |
 
 ## Behavior
 
@@ -54,11 +57,51 @@ See the [diagnostic codes](../diagnostics.md) page for the registry of
 | `0` | parsed and lowered without errors |
 | `1` | one or more diagnostics emitted, or an I/O error |
 
+## Structured-result JSON (`--json`, v0.45 T3)
+
+With `--json` (or `--format json-result`), `mty check` emits a single
+JSON document on stdout instead of the ariadne pretty report. This is
+the "agent command surfaces" shape every other v0.45 surface (LSP,
+runtime control paths, `mty agent`'s `check` op via `result.result`)
+is migrating to. The exit code is preserved (`0` if `ok:true`,
+non-zero otherwise) and ariadne text is fully suppressed under
+`--json` — agents can `serde_json::from_str(&stdout)` without
+pre-stripping.
+
+```json
+{
+  "ok": false,
+  "path": "src/main.mty",
+  "diagnostics": [
+    {
+      "code": "MT2001",
+      "severity": "error",
+      "message": "type mismatch: expected Str, found I32",
+      "span": {
+        "file": "src/main.mty",
+        "line": 12, "col": 5,
+        "end_line": 12, "end_col": 18
+      }
+    }
+  ]
+}
+```
+
+The richer NDJSON envelope path (`--format json`) is unchanged and
+continues to drive `mty fix --apply --from-stdin` and the agent-mode
+protocol. See
+[`docs/internals/diagnostic-envelopes.md`](../../internals/diagnostic-envelopes.md)
+for the envelope schema. The simpler structured-result shape above is
+documented in
+[`crates/mty-diagnostics/src/fix.rs`](../../../crates/mty-diagnostics/src/fix.rs)
+(`CheckResult` / `CheckDiagnostic`).
+
 ## Examples
 
 ```bash
 mty check src/main.mty
 mty check examples/07_agent_echo.mty
+mty check --json src/main.mty | jq '.diagnostics[].code'
 ```
 
 In CI:


### PR DESCRIPTION
## Summary

Adds `mty check --json` flag emitting one structured JSON document on stdout:

\`\`\`json
{
  \"ok\": false,
  \"path\": \"...\",
  \"diagnostics\": [
    {\"code\": \"MT2001\", \"severity\": \"error\", \"message\": \"...\",
     \"span\": {\"file\": \"...\", \"line\": 12, \"col\": 5, \"end_line\": 12, \"end_col\": 18}}
  ]
}
\`\`\`

Distinct from the existing \`--format json\` NDJSON envelope (one line per diagnostic, used by \`mty fix --apply\`). Token v0.45 contribution to the longer agent-results migration tracked in RELEASE-v0.45.md.

Same surface mirrored on \`mty agent\` NDJSON protocol's \`check\` op so LSPs and CI consumers can stop parsing ariadne text.

## Test plan
- [x] \`mty check --json clean.mty\` → \`{ok:true, diagnostics:[]}\`, exit 0
- [x] \`mty check --json two_type_errors.mty\` → 2 distinct line:col, exit 1
- [x] \`mty check --json undefined_name.mty\` → name-resolution diagnostic, exit 1
- [x] \`mty check --json parse_glitch.mty\` → parse-phase diagnostic, exit 1
- [x] Without \`--json\`: ariadne pretty path unchanged (back-compat)
- [x] \`mty agent\` \`check\` op responds with structured shape
- [x] All 115 mty-diagnostics tests pass