### PR TITLE
v0.45: scripts/test-like-gha local CI-mimic

### DIFF
--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -30,6 +30,13 @@
 # --check` on Linux catches — the cargo-fmt + clippy gate didn't see it.
 # This step bakes that check into the local push.
 #
+# v0.45 T4: optional `MTY_PRE_PUSH_GHA=1` env runs
+# `scripts/test-like-gha.sh` (cargo test --workspace under the same
+# disk profile GHA uses) at the end of the hook. Off by default so
+# the normal push stays fast; on for codegen-heavy / test-heavy work
+# where the v0.42 T1 "passed locally, SIGSEGV on GHA Ubuntu" trap is a
+# real risk.
+#
 
 set -euo pipefail
 
@@ -104,6 +111,26 @@ if [ ${#MTY_FILES[@]} -gt 0 ]; then
   echo "[mty pre-push] mty fmt OK (${#MTY_FILES[@]} files)"
 else
   echo "[mty pre-push] mty fmt OK (no .mty files in known paths)"
+fi
+
+# v0.45 T4: opt-in `cargo test --workspace` under the GHA disk profile.
+# Off by default so the normal push (fmt + clippy + mty fmt) stays at
+# the 60-second-budget the v0.34 T4 hook aimed for. Codegen / test
+# tracks that want to dogfood the runner's exact configuration enable
+# it with `MTY_PRE_PUSH_GHA=1 git push`. Honors `$CARGO_TARGET_DIR`
+# via the underlying script.
+if [ "${MTY_PRE_PUSH_GHA:-0}" = "1" ]; then
+  if [ -x "scripts/test-like-gha.sh" ]; then
+    echo "[mty pre-push] MTY_PRE_PUSH_GHA=1 — scripts/test-like-gha.sh"
+    if ! MTY_TEST_LIKE_GHA_QUIET=1 bash scripts/test-like-gha.sh; then
+      echo "[mty pre-push] test-like-gha failed. Fix or unset MTY_PRE_PUSH_GHA." >&2
+      exit 1
+    fi
+    echo "[mty pre-push] test-like-gha OK"
+  else
+    echo "[mty pre-push] MTY_PRE_PUSH_GHA=1 but scripts/test-like-gha.sh missing/not executable" >&2
+    exit 1
+  fi
 fi
 
 echo "[mty pre-push] OK"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,15 @@ Issues are welcome. Pull requests must:
 CI runs the same three commands on every PR — see
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
+For a closer-to-real preview of what the GitHub Actions runners will
+do (Linux/macOS test mode + Windows-serial test mode + the dropped
+debuginfo profile that keeps Ubuntu under its disk ceiling), run
+[`scripts/test-like-gha.sh`](scripts/test-like-gha.sh) or its Windows
+sibling [`scripts/test-like-gha.ps1`](scripts/test-like-gha.ps1)
+before you push. See
+[docs/contributing.md](docs/contributing.md#scriptstest-like-ghash--v045-t4)
+for when to reach for it.
+
 For everything else — workflow, style, design discussions — see
 [docs/contributing.md](docs/contributing.md).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,6 +89,41 @@ MTY_PRE_PUSH_SKIP=1 git push
 
 Uninstall: `mty hooks uninstall`.
 
+### `scripts/test-like-gha.sh` (v0.45 T4)
+
+`scripts/test-like-gha.sh` (and the equivalent `.ps1` for Windows
+PowerShell) runs `cargo test --workspace` under the exact same
+configuration the GitHub Actions runners use: `RUSTFLAGS=-D warnings`,
+`CARGO_PROFILE_DEV_DEBUG=0` + `CARGO_PROFILE_TEST_DEBUG=0` (drops
+debuginfo to keep Linux runners under their disk ceiling), and the
+Windows leg routes to `cargo test --workspace -- --test-threads=1
+--nocapture` so behaviour matches the Windows runner's serial-test
+mode. `$CARGO_TARGET_DIR` is honored so a per-worktree target dir is
+respected.
+
+Use this script before pushing whenever your change touches codegen,
+the test harness, or anything else that could expose a disk-pressure
+or threading regression. The cautionary example is the **v0.42 T1
+incident** (recapped in `RELEASE-v0.44.md`): the L28/L21 Vec fix was
+"verified-fixed-and-locked" on Vulcan Linux and on local Windows, but
+GHA Ubuntu SIGSEGV'd the regression tests because debuginfo-heavy
+test binaries blew past the small ephemeral disk and produced
+truncated artifacts the test harness then crashed on. v0.44 main CI
+had to rerun two infra-failed jobs to clear the same trap. The CI-side
+fix (drop debuginfo + Windows serial) ships from
+`codex/ci-disk-headroom`; `scripts/test-like-gha.sh` is the local
+mirror so swarm agents stop discovering that class of regression *on
+the runner*.
+
+Optional pre-push integration: set `MTY_PRE_PUSH_GHA=1` and the
+pre-push hook will, after fmt + clippy + mty-fmt-check, invoke
+`scripts/test-like-gha.sh`. Off by default to keep the normal push
+fast; flip it on for the duration of a codegen-heavy track:
+
+```bash
+MTY_PRE_PUSH_GHA=1 git push
+```
+
 **REQUIRED for swarm agents.** The v0.27 / v0.30 / v0.32 / v0.33
 retros all surfaced the same failure mode: a swarm agent pushed a
 branch that passed local Windows checks but failed Linux-side

--- a/scripts/test-like-gha.ps1
+++ b/scripts/test-like-gha.ps1
@@ -1,0 +1,73 @@
+# scripts/test-like-gha.ps1 — v0.45 T4
+#
+# Run `cargo test --workspace` with the same disk-pressure profile and
+# Windows-serial test path that the GitHub Actions Windows runner uses,
+# so a Windows swarm-agent can dogfood the real CI configuration BEFORE
+# pushing.
+#
+# Why this exists (the v0.42 T1 incident, recapped in v0.44 release
+# notes): a track shipped what looked like a green fix — Vulcan Linux
+# passed, local Windows passed — but GHA Ubuntu SIGSEGV'd the
+# regression tests. Root cause was GitHub runner disk exhaustion:
+# debuginfo-heavy test binaries exceeded the small ephemeral disk
+# ceiling and produced truncated artifacts the test harness crashed on.
+# v0.44 had to rerun two infra-failed jobs. The fix on the CI side
+# lives in `.github/workflows/ci.yml` (also coming via
+# `codex/ci-disk-headroom`): drop debuginfo on the dev/test profiles
+# and force Windows to `--test-threads=1`. This script is the local
+# mirror for Windows dev boxes.
+#
+# Envs set (must match `.github/workflows/ci.yml`):
+#
+#   CARGO_TERM_COLOR=always
+#   RUSTFLAGS=-D warnings
+#   CARGO_PROFILE_DEV_DEBUG=0
+#   CARGO_PROFILE_TEST_DEBUG=0
+#
+# Always runs the Windows serial test path:
+#
+#   cargo test --workspace -- --test-threads=1 --nocapture
+#
+# `$env:CARGO_TARGET_DIR` is honored so parallel-worktree agents using
+# per-worktree target dirs (mandated by
+# feedback_mighty_target_dir_isolation) do not collide.
+#
+# Usage:
+#
+#     scripts/test-like-gha.ps1
+#
+# Pre-push integration: set $env:MTY_PRE_PUSH_GHA = "1" to have the
+# pre-push hook (a bash script) also invoke scripts/test-like-gha.sh on
+# the next push.
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+$quiet = $env:MTY_TEST_LIKE_GHA_QUIET
+if (-not $quiet) { $quiet = "0" }
+
+if ($quiet -ne "1") {
+    Write-Host "================================================================"
+    Write-Host "  Running tests with GHA disk profile (scripts/test-like-gha.ps1)"
+    Write-Host "  CARGO_PROFILE_DEV_DEBUG=0   CARGO_PROFILE_TEST_DEBUG=0"
+    Write-Host "  RUSTFLAGS=-D warnings        CARGO_TERM_COLOR=always"
+    Write-Host "  Windows serial → cargo test --workspace -- --test-threads=1 --nocapture"
+    if ($env:CARGO_TARGET_DIR) {
+        Write-Host "  CARGO_TARGET_DIR=$($env:CARGO_TARGET_DIR)"
+    }
+    Write-Host "================================================================"
+}
+
+$env:CARGO_TERM_COLOR = "always"
+if (-not $env:RUSTFLAGS) {
+    $env:RUSTFLAGS = "-D warnings"
+}
+$env:CARGO_PROFILE_DEV_DEBUG = "0"
+$env:CARGO_PROFILE_TEST_DEBUG = "0"
+
+# `--%` stops PowerShell argument parsing so `--test-threads=1` reaches
+# the test harness intact rather than being eaten as a PS switch.
+cargo test --workspace --% -- --test-threads=1 --nocapture
+exit $LASTEXITCODE

--- a/scripts/test-like-gha.sh
+++ b/scripts/test-like-gha.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scripts/test-like-gha.sh — v0.45 T4
+#
+# Run `cargo test --workspace` with the same disk-pressure profile and
+# Windows-serial test path that GitHub Actions Ubuntu/macOS/Windows
+# runners use. This lets a swarm agent dogfood a realistic preview of
+# what main CI will do BEFORE pushing.
+#
+# Why this exists (the v0.42 T1 incident, recapped in v0.44 release
+# notes): a track shipped what looked like a green fix — Vulcan Linux
+# passed, local Windows passed — but GHA Ubuntu SIGSEGV'd the
+# regression tests. Root cause was GitHub runner disk exhaustion:
+# debuginfo-heavy test binaries exceeded the small ephemeral disk
+# ceiling and produced truncated artifacts that the test harness then
+# crashed on. v0.44 had to rerun two infra-failed jobs. The fix on
+# the CI side lives in `.github/workflows/ci.yml` (also coming via
+# `codex/ci-disk-headroom`): drop debuginfo on the dev/test profiles
+# and force Windows to `--test-threads=1`. This script mirrors that
+# exact configuration locally so the next swarm-agent track doesn't
+# get a "passed locally, exploded on GHA" surprise.
+#
+# Envs set (must match `.github/workflows/ci.yml`):
+#
+#   CARGO_TERM_COLOR=always
+#   RUSTFLAGS=-D warnings
+#   CARGO_PROFILE_DEV_DEBUG=0    # drop debuginfo on dev profile
+#   CARGO_PROFILE_TEST_DEBUG=0   # drop debuginfo on test profile
+#
+# OS routing:
+#
+#   Linux / macOS  → cargo test --workspace
+#   Windows (msys / cygwin / mingw bash) → cargo test --workspace
+#                                          -- --test-threads=1 --nocapture
+#
+# `$CARGO_TARGET_DIR` is honored so parallel-worktree agents using
+# per-worktree target dirs (mandated by feedback_mighty_target_dir_isolation)
+# do not collide.
+#
+# Exit code is the cargo-test exit code.
+#
+# Usage:
+#
+#     scripts/test-like-gha.sh
+#
+# Bypass nothing — this script does NOT take `--no-verify` style
+# escapes. It is meant to be run before push, on top of the existing
+# pre-push hook (which gates fmt + clippy + mty-fmt). Optional
+# pre-push integration: set MTY_PRE_PUSH_GHA=1 to have the hook also
+# invoke this script on the next push.
+
+set -euo pipefail
+
+# Optional override: callers may set MTY_TEST_LIKE_GHA_QUIET=1 to
+# suppress the banner (useful when the pre-push hook invokes us).
+QUIET="${MTY_TEST_LIKE_GHA_QUIET:-0}"
+
+# OS detection — mirror the same matrix-leg routing CI uses. Treat any
+# MSYS/MINGW/CYGWIN bash on Windows as the Windows leg.
+case "${OSTYPE:-}" in
+  msys*|cygwin*|win32*) IS_WINDOWS=1 ;;
+  *)
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+      MINGW*|MSYS*|CYGWIN*|Windows_NT) IS_WINDOWS=1 ;;
+      *) IS_WINDOWS=0 ;;
+    esac
+    ;;
+esac
+
+if [ "$QUIET" != "1" ]; then
+  echo "================================================================"
+  echo "  Running tests with GHA disk profile (scripts/test-like-gha.sh)"
+  echo "  CARGO_PROFILE_DEV_DEBUG=0   CARGO_PROFILE_TEST_DEBUG=0"
+  echo "  RUSTFLAGS=-D warnings        CARGO_TERM_COLOR=always"
+  if [ "$IS_WINDOWS" = "1" ]; then
+    echo "  Windows detected → cargo test --workspace -- --test-threads=1 --nocapture"
+  else
+    echo "  Linux/macOS      → cargo test --workspace"
+  fi
+  if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    echo "  CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
+  fi
+  echo "================================================================"
+fi
+
+export CARGO_TERM_COLOR=always
+export RUSTFLAGS="${RUSTFLAGS:--D warnings}"
+export CARGO_PROFILE_DEV_DEBUG=0
+export CARGO_PROFILE_TEST_DEBUG=0
+
+if [ "$IS_WINDOWS" = "1" ]; then
+  cargo test --workspace -- --test-threads=1 --nocapture
+else
+  cargo test --workspace
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/test-like-gha.sh` and `scripts/test-like-gha.ps1` that run `cargo test --workspace` under the exact GHA disk profile (`CARGO_PROFILE_DEV_DEBUG=0` + `CARGO_PROFILE_TEST_DEBUG=0`) and route to the Windows-serial test path (`--test-threads=1 --nocapture`) on Windows, so a swarm agent can dogfood the runner configuration BEFORE pushing.
- Wires an opt-in `MTY_PRE_PUSH_GHA=1` path into the pre-push hook (`.git-hooks/pre-push`) that invokes the script after the existing fmt + clippy + mty-fmt gates. Off by default to keep the normal push fast; on for codegen-heavy work.
- Documents when to reach for the script in `CONTRIBUTING.md` and `docs/contributing.md`, including the v0.42 T1 cautionary tale.

## Why this exists — the v0.42 T1 incident

v0.42 T1 (`merge v0.42-t1: cranelift+LLVM Vec liveness fix (L28/L21)`) claimed L28/L21 were "verified-fixed-and-locked" — Vulcan Linux passed and local Windows passed — **but GHA Ubuntu SIGSEGV'd** the regression tests under disk pressure. v0.44's release notes ([`dev/history/releases/RELEASE-v0.44.md`](../blob/codex/v045-test-like-gha/dev/history/releases/RELEASE-v0.44.md)) recap: *"Main CI passed after rerunning two infrastructure-failed jobs that hit GitHub runner disk exhaustion."* The CI-side fix is in flight as `codex/ci-disk-headroom` (PR #22). This PR is the LOCAL-side mirror so the next swarm-agent track doesn't get a "passed locally, exploded on GHA Ubuntu" surprise.

## Dogfood result (and a real finding)

Dogfooding `scripts/test-like-gha.sh` on `origin/main` reproduces the v0.42 T1 trap LOCALLY on Windows: `mty_codegen_cranelift::vec_liveness_v042::l28_helper_param_grow_returns_grown_vec` SIGSEGVs with `STATUS_ACCESS_VIOLATION` (0xC0000005) under `CARGO_PROFILE_DEV_DEBUG=0` / `CARGO_PROFILE_TEST_DEBUG=0`, while passing cleanly under the default `debug = 2` profile. This is exactly the regression class the script was built to surface, and it validates that the script works as intended. It is, separately, a follow-up bug to file against the L28 fix (the disk-headroom CI change will surface it on every run; investigating the underlying codegen bug is out of T4 scope).

## Test plan

- [x] `scripts/test-like-gha.sh` runs and routes correctly (Windows detected → serial test mode + GHA envs)
- [x] `scripts/test-like-gha.ps1` runs and routes correctly (Windows serial mode)
- [x] Pre-push hook still passes the normal fmt + clippy + mty-fmt gates
- [x] `MTY_PRE_PUSH_GHA=1` gate-path opt-in shipped; defaults to off
- [x] Local gates run before push: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --release --bin mty`, `mty fmt --check examples/ crates/mty-stdlib/src/`
- [ ] Investigate the `l28_helper_param_grow_returns_grown_vec` SIGSEGV under `CARGO_PROFILE_DEV_DEBUG=0` (separate follow-up; not blocking this PR)

DO NOT merge directly — integrator handles it.

Generated with Claude Code