### PR TITLE
v0.45: actually fix L28 — works under debug=0 profile

### DIFF
--- a/crates/mty-codegen-cranelift/src/aggregate.rs
+++ b/crates/mty-codegen-cranelift/src/aggregate.rs
@@ -53,6 +53,33 @@ pub fn is_aggregate(t: &IrTy) -> bool {
     )
 }
 
+/// v0.45 T5 (L28 debug=0 fix): an "opaque" ADT (no constructable
+/// variants, registered by the prelude — `Vec`, `Page`, `IoErr`, …) is
+/// modelled at runtime as an i64 *pointer* to a runtime-allocated
+/// header (the Vec header is 32 bytes; the layout system reports it
+/// as `Layout::scalar(PTR_BYTES)` because the body is invisible to
+/// the front-end). The catch: [`is_aggregate`] still returns `true`
+/// for opaque ADTs so that `place_addr` / `agg_addr` route reads
+/// through the i64 Variable that holds the header pointer. The
+/// memcpy-into-a-fresh-slot path in `lower_assign`'s
+/// `Rvalue::Use(Copy/Move)` branch, however, would copy only 8 bytes
+/// of the actual 32-byte header into an 8-byte stack slot — silently
+/// truncating `cap`, `data`, and `elem_size` — and then return a
+/// dangling stack pointer when the local escapes the frame (see
+/// `tests/vec_liveness_v042.rs::l28_helper_param_grow_returns_grown_vec`).
+///
+/// This helper lets the lowerer detect that case and rebind the
+/// destination Variable to the *value* the source Variable holds (the
+/// header pointer) instead of memcpy-ing the truncated header.
+pub fn is_opaque_adt(t: &IrTy, adts: &[AdtRef]) -> bool {
+    if let IrTy::Adt(id, _) = t {
+        if let Some(adt) = adts.iter().find(|a| a.adt == *id) {
+            return adt.variants.is_empty();
+        }
+    }
+    false
+}
+
 /// Compute layout for a SIR type (delegates to `layout_with_adts` for
 /// aggregates; calls into primitive_layout for scalars).
 pub fn type_layout(t: &IrTy, adts: &[AdtRef]) -> Layout {

--- a/crates/mty-codegen-cranelift/src/lower.rs
+++ b/crates/mty-codegen-cranelift/src/lower.rs
@@ -27,8 +27,8 @@
 
 use crate::abi::{build_signature, cl_ty_for, cl_ty_for_variadic, host_call_conv};
 use crate::aggregate::{
-    field_load_ty, is_aggregate, slot_size, struct_field_offset, tuple_offset, type_align,
-    type_size, variant_field_offset, TAG_OFFSET, TAG_SIZE,
+    field_load_ty, is_aggregate, is_opaque_adt, slot_size, struct_field_offset, tuple_offset,
+    type_align, type_size, variant_field_offset, TAG_OFFSET, TAG_SIZE,
 };
 use crate::error::{CodegenError, CompileResult};
 use crate::runtime_imports;
@@ -1229,6 +1229,37 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
             if let Rvalue::Use(Operand::Copy(src) | Operand::Move(src)) = rv {
                 let src_ty = self.place_type(src);
                 if is_aggregate(&src_ty) && src.proj.is_empty() {
+                    // v0.45 T5 (L28 debug=0 fix): opaque ADTs (Vec /
+                    // Page / IoErr / … — registered by the prelude with
+                    // no constructable variants) are passed around as
+                    // i64 pointers to a runtime-allocated header. The
+                    // layout system reports them as `Layout::scalar(8)`
+                    // because the body is invisible to the front-end;
+                    // memcpy-ing 8 bytes from `src` into a fresh slot
+                    // would truncate the actual 32-byte Vec header
+                    // (dropping `cap`, `data`, `elem_size`) and then
+                    // hand back a dangling stack pointer once the
+                    // local escapes the frame. Re-bind the Variable to
+                    // the source pointer value instead — that mirrors
+                    // what the LLVM backend already does (Adt → ptr →
+                    // load/store the pointer word) and what the
+                    // direct-`Vec.new()` floor case relies on. Pre-fix
+                    // this corruption "worked" under `[profile.dev]
+                    // opt-level=0 + debug=2` because Cranelift's
+                    // unoptimised register allocator parked the slot
+                    // address in a frame slot the OOB stores happened
+                    // to leave intact long enough for `g.len()` to
+                    // read it back; any other profile (debug=0,
+                    // opt-level≥1) lost the bytes and SEGV'd.
+                    if is_opaque_adt(&local_ty, &self.prog.adts)
+                        || is_opaque_adt(&src_ty, &self.prog.adts)
+                    {
+                        let var = self.ensure_var(place.local);
+                        let src_val = self.eval_operand(&Operand::Copy(src.clone()))?;
+                        let val = self.coerce_to(src_val, ct::I64);
+                        self.b.def_var(var, val);
+                        return Ok(());
+                    }
                     let (src_addr, _src_ty2) = self.place_addr(src)?;
                     let _ = self.ensure_var(place.local);
                     let dst_addr = self.agg_slot_addr(place.local)?;

--- a/crates/mty-codegen-cranelift/tests/vec_liveness_v042.rs
+++ b/crates/mty-codegen-cranelift/tests/vec_liveness_v042.rs
@@ -151,10 +151,6 @@ fn main() -> I64 {
 /// inside, and returns the grown Vec. The helper's body has the same
 /// rebind-across-back-edge pattern; the bug should surface here too.
 #[test]
-#[cfg_attr(
-    any(target_os = "linux", target_os = "macos"),
-    ignore = "Unix JIT currently crashes in this stress shape; native Vec-liveness coverage remains active"
-)]
 fn l28_helper_param_grow_returns_grown_vec() {
     let src = r#"
 fn grow(v0: Vec[I32], n: USize) -> Vec[I32] {
@@ -190,10 +186,6 @@ fn main() -> I64 {
 /// liveness paths must survive — outer back-edge keeps `v` alive across
 /// inner's pushes; inner back-edge keeps `v` alive across its own.
 #[test]
-#[cfg_attr(
-    any(target_os = "linux", target_os = "macos"),
-    ignore = "Unix JIT currently crashes in this stress shape; native Vec-liveness coverage remains active"
-)]
 fn l28_push_in_nested_loop() {
     let src = r#"
 fn main() -> I64 {
@@ -349,5 +341,95 @@ fn main() -> I64 {
         must_run(src),
         12,
         "L21: two back-to-back nested loops both reach the Vec param"
+    );
+}
+
+// =====================================================================
+// v0.45 T5 (L28 debug=0 regression) — opaque-ADT Use-Copy must not
+// memcpy. Vec is an opaque prelude ADT modelled at runtime as an i64
+// pointer to a 32-byte header. `let mut v = v0` inside a helper would
+// previously memcpy 8 bytes (the layout system's reported pointer-
+// width "size") of the 32-byte header into a fresh stack slot, and
+// then return the slot address — silently truncating `cap`, `data`,
+// `elem_size` and handing back a dangling stack pointer once the
+// helper returned. The bug "worked" only under the host Rust build's
+// `[profile.dev] opt-level=0 + debug=2` accident: the unoptimised
+// register allocator kept the slot's bytes intact across the
+// load/store dance long enough for `g.len()` to read the right
+// value. Under `CARGO_PROFILE_DEV_DEBUG=0` (the GHA-mimic profile)
+// or any opt-level≥1 the stack was overwritten and the JIT SEGV'd.
+//
+// These tests pin the *shape* — they're stronger than the
+// `l28_helper_param_grow_returns_grown_vec` shape because they
+// isolate the param-rebind from `v.push()`'s realloc, so a future
+// refactor of `emit_vec_push` can't accidentally hide the bug.
+// =====================================================================
+
+/// Param-rebind-without-mutation floor: `let mut v = v0; v.len()` must
+/// return the same length as `v0.len()`. Pre-fix this returned 0 (the
+/// truncated-slot's `len` happened to be 0 because nothing wrote it).
+#[test]
+fn l28_helper_param_rebind_preserves_len() {
+    let src = r#"
+fn identity_len(v0: Vec[I32]) -> I64 {
+  let mut v = v0
+  let mut n: I64 = 0
+  let mut i: USize = 0
+  while i < v.len() {
+    n = n + 1
+    i = i + 1
+  }
+  n
+}
+
+fn main() -> I64 {
+  let mut v: Vec[I32] = Vec.new()
+  let mut k: USize = 0
+  while k < 7 {
+    v = v.push(1)
+    k = k + 1
+  }
+  identity_len(v)
+}
+"#;
+    assert_eq!(
+        must_run(src),
+        7,
+        "v0.45 T5: param `let mut v = v0` must preserve the Vec header pointer"
+    );
+}
+
+/// Param-rebind-then-return: the helper rebinds, does nothing else,
+/// and returns the Vec. Caller must observe the same length. Pre-fix
+/// the return value was a dangling stack-slot pointer.
+#[test]
+fn l28_helper_param_rebind_returns_same_vec() {
+    let src = r#"
+fn pass_through(v0: Vec[I32]) -> Vec[I32] {
+  let mut v = v0
+  v
+}
+
+fn main() -> I64 {
+  let mut v: Vec[I32] = Vec.new()
+  let mut k: USize = 0
+  while k < 5 {
+    v = v.push(1)
+    k = k + 1
+  }
+  let g = pass_through(v)
+  let mut n: I64 = 0
+  let mut j: USize = 0
+  while j < g.len() {
+    n = n + 1
+    j = j + 1
+  }
+  n
+}
+"#;
+    assert_eq!(
+        must_run(src),
+        5,
+        "v0.45 T5: param-rebind-then-return must not truncate or dangle"
     );
 }


### PR DESCRIPTION
## Summary

- v0.42 T1's L28 "fix" was an accident of the workspace default `[profile.dev]` (`opt-level=0 + debug=2`). The underlying Cranelift codegen bug remained and surfaced as a SIGSEGV (`STATUS_ACCESS_VIOLATION`, 0xC0000005) under the GHA-mimic `CARGO_PROFILE_DEV_DEBUG=0 / CARGO_PROFILE_TEST_DEBUG=0` envs (v0.45 T4) and under any `opt-level >= 1` build. v0.44 attributed the failure to GHA runner disk exhaustion; reproducing locally with the GHA envs showed the bug was real and in our backend.
- Root cause: `Vec[T]` is an *opaque* prelude ADT, modelled at runtime as an i64 pointer to a 32-byte header. `crate::aggregate::is_aggregate` returns `true` for any `IrTy::Adt`, so `lower_assign`'s aggregate-Copy branch ran the memcpy-into-fresh-slot path for `let mut v = v0` and `let mut v = arg`. The layout system reports opaque ADTs as `Layout::scalar(PTR_BYTES)`, so the memcpy copied 8 bytes of the 32-byte header into an 8-byte slot, then `def_var`'d the dest Variable to the slot address — silently truncating `cap`/`data`/`elem_size` and returning a dangling stack pointer when the helper escaped the frame. Under the default profile the OOB stores happened to land on bytes the Rust frame allocator left intact long enough for `g.len()` to read the right `len` back; under any other profile the bytes were overwritten and the JIT SEGV'd.
- Fix: add `aggregate::is_opaque_adt(&IrTy, &[AdtRef])`. In `lower_assign`'s aggregate-Copy/Move branch, short-circuit when either side is an opaque ADT — just `eval_operand` the source pointer and `def_var` it into the dest Variable. This matches what the LLVM backend already does (`llvm_ty(IrTy::Adt) -> ptr`, `lower_assign` is a single `build_store`), so no LLVM port is needed.
- Unignores the Linux/macOS branches of `l28_helper_param_grow_returns_grown_vec` and `l28_push_in_nested_loop` (the v0.42 workaround was hiding the same bug on Unix). Adds two new pinpoint regressions (`l28_helper_param_rebind_preserves_len`, `l28_helper_param_rebind_returns_same_vec`) that isolate the param-rebind from `v.push()`'s realloc so a future refactor of `emit_vec_push` cannot accidentally re-hide the bug.
- Unblocks #22 (`codex/ci-disk-headroom`). Once that merges, every main CI run starts hitting this SEGV unless this lands first.

## Test plan

- [x] Reproduce: `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p mty-codegen-cranelift --test vec_liveness_v042 -- l28_helper_param_grow_returns_grown_vec` SEGV'd on origin/main (Windows + Linux).
- [x] All 8 `vec_liveness_v042` tests pass on Windows under both default `[profile.dev]` and `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0`.
- [x] All 8 tests pass on Linux (vulcan, V100, Ubuntu 24.04) under `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0` — including the previously-ignored Linux/macOS branches.
- [x] Full `mty-codegen-cranelift` crate (~250 tests across 16 files) green on Windows under both profiles.
- [x] Full `cargo test --workspace` on vulcan under `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0` — no failures or panics.
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `mty fmt --check examples/ crates/mty-stdlib/src/` clean.
- [x] CLIF dump for `grow(v0: Vec[I32], n) -> Vec[I32]`: pre-fix had `v2 = stack_addr.i64 ss0; v3 = load.i64 v0; store v3, v2; jump block1(..., v2)` (slot-truncation). Post-fix: `jump block1(..., v0)` — the Vec header pointer flows through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)