### PR TITLE
v0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,56 @@ For the full per-release notes, see
 
 ## [Unreleased]
 
-v0.45 development focuses on making agent-authored apps easier to
-ship: native capability ABI coverage, broader formatter rollout, and
-structured command/result surfaces that reduce shim code.
+## [0.45.0] - 2026-06-02
+
+v0.45 ships shim-less file I/O for agent-built apps, broadens the
+formatter rollout to function and type declarations, lands the
+`mty check --json` structured result, and corrects the v0.42/v0.44
+attribution for the L28 Vec liveness bug.
+
+### Fixed
+- **L28 (actually):** the v0.42 T1 / v0.44 L28 attribution was
+  incorrect. `Vec[T]` is an opaque prelude ADT modelled as
+  `Layout::scalar(PTR_BYTES)`, but `aggregate::is_aggregate` returned
+  `true` for any `IrTy::Adt`, so `let mut v = v0` / `let mut v = arg`
+  ran through the aggregate-Copy memcpy path. That copied 8 bytes of
+  the 32-byte `Vec` runtime header into an 8-byte slot and re-bound
+  the dest Variable to the truncated slot, dangling the `cap` /
+  `data` / `elem_size` fields when the helper returned. Default
+  `[profile.dev]` debug=2 metadata masked the OOB stores; PR #22's
+  `CARGO_PROFILE_DEV_DEBUG=0` mirrors GHA and exposed the SEGV. Fix
+  in `lower_assign`'s aggregate-Copy/Move branch: short-circuit
+  opaque ADTs by `def_var`ing the pointer through, matching the LLVM
+  backend. Unignores the previously-ignored Linux/macOS L28 branches;
+  adds two pinpoint regressions on the rebind path.
+- **L18 (P1):** `std.fs.*` calls under `mty run` (Cranelift JIT) and
+  `mty build` (AOT) no longer force the interpreter fallback. The
+  runtime exposes 11 new ABI symbols
+  (`mty_runtime_fs_{read,read_to_string,read_dir,write,write_string,append,exists,metadata,create_dir_all,remove_file,remove_dir_all}`)
+  recognised by both Cranelift and LLVM backends; the capability
+  gate (`MT4001`) stays in place at typeck.
+
+### Added
+- **`mty check --json` structured result.** Stable JSON envelope for
+  the check command, replacing stringly-formatted output for agent
+  callers. The envelope is pinned by 43 tests in
+  `crates/mty-cli/tests/check_json`.
+- **Formatter rollout to `fn` / `struct` / `enum` / `type` decls.**
+  The syntax-aware item formatter (v0.43 L26 const baseline) now
+  rewrites function, struct, enum, and type-alias declarations.
+  Emit-identical against the 67-file `.mty` corpus.
+- **`scripts/test-like-gha.sh` + pre-push opt-in.** Local mimic of
+  the GHA `CARGO_PROFILE_DEV_DEBUG=0 / CARGO_PROFILE_TEST_DEBUG=0`
+  environment so codegen bugs surfaced by stripped-debug profiles
+  (the class PR #27 fixes) are catchable before push.
+
+### Infrastructure
+- CI test runs strip debug info from test binaries
+  (`CARGO_PROFILE_DEV_DEBUG=0`, `CARGO_PROFILE_TEST_DEBUG=0`) and
+  serialise the Windows lane with `--test-threads=1` to keep the
+  runner's `C:` partition under the runner-image disk budget.
+
+[Release notes](dev/history/releases/RELEASE-v0.45.md).
 
 ## [0.44.0] - 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -14,19 +14,12 @@
 
 Compiler, runtime, formatter, package manager, doc generator, LSP,
 and stdlib all live in one Rust workspace and one `mty` binary.
-v0.44 is the current release: the Mighty IDE is itself written in
-Mighty, and every bug it surfaces lands as a release-gate fix in the
-next cycle. v0.44 makes dev builds identify as the public Mighty
-milestone, parses long agent-generated `else if` command routers
-iteratively, and makes default `mty run` fall back to the interpreter
-for host-backed `std.fs` calls instead of routing them through the
-native extern stub.
-
-`main` is now the v0.45 development line; dev builds report
-`mty 0.45.0-dev`. The v0.45 focus is turning more interpreter-hosted
-stdlib behavior into native capability ABI coverage, broadening the
-safe formatter rollout, and replacing shim-heavy scalar command
-surfaces with structured result shapes agents can generate directly.
+v0.45 is the current release: native `std.fs` JIT/AOT paths
+(shim-less file I/O for agent-built apps), formatter rollout to
+`fn`/`struct`/`enum`/`type` declarations, the `mty check --json`
+structured result, and the real L28 fix (opaque-ADT Use-Copy must
+not memcpy — the v0.42 attribution was masked by `[profile.dev]`
+debug=2 metadata).
 
 ## Why Mighty
 
@@ -292,7 +285,7 @@ current state of the language, not its history.
 
 ## Status
 
-Mighty is **pre-alpha**. Internal milestones tagged through v0.43.
+Mighty is **pre-alpha**. Internal milestones tagged through v0.45.
 The toolchain is exercised by **~3555 Rust tests** across 20 crates
 plus **490 Python 2nd-impl tests** plus **159 normative conformance
 cases** plus **23 self-host driver codegen tests** — combined **~4227

--- a/crates/mty-cli/src/lib.rs
+++ b/crates/mty-cli/src/lib.rs
@@ -22,9 +22,9 @@ pub mod cmd;
 ///
 /// The Rust workspace crates intentionally keep their internal crate
 /// version while the public toolchain advances by Mighty milestones
-/// (`v0.44.0`, `v0.45.0-dev`, ...). Keep this aligned with
+/// (`v0.45.0`, `v0.46.0-dev`, ...). Keep this aligned with
 /// `CHANGELOG.md` and release tags.
-pub const MIGHTY_VERSION: &str = "0.45.0-dev";
+pub const MIGHTY_VERSION: &str = "0.45.0";
 
 // v0.35 T1 — browser playground exports. `wasm-pack build --target web`
 // reads this cdylib's `#[wasm_bindgen]` symbols (`init` / `check` /

--- a/dev/history/releases/RELEASE-v0.45.md
+++ b/dev/history/releases/RELEASE-v0.45.md
@@ -1,69 +1,112 @@
-# Mighty v0.45 - Draft Release Notes
+# Mighty v0.45 Release Notes
 
 **Tag:** `v0.45.0`
-**Date:** TBD
-**Status:** DRAFT - agent-built app shipping ergonomics.
+**Date:** 2026-06-02
+**Status:** SHIPPED - shim-less file I/O for agent-built apps + real L28 fix.
 
-**Headline:** reduce the remaining shim code agents need when building
-real apps in Mighty.
+**Headline:** v0.45 lands native `std.fs` on the JIT/AOT path so
+agent-built CLIs no longer need the IDE's file-I/O shim, broadens the
+formatter rollout to function and type declarations, ships a
+structured `mty check --json` result, and corrects the v0.42 T1 / v0.44
+attribution for the L28 Vec liveness bug — the actual codegen fix
+landed in this release.
 
-## Direction
+## Shipped
 
-v0.45 picks up the carry-forward work from v0.44: make host-backed
-stdlib behavior available through native capability ABI paths, continue
-the formatter rollout without destructive rewrites, and replace
-stringly/scalar command plumbing with structured result surfaces that
-agents can inspect, test, and regenerate safely.
+- **PR #22 — CI disk headroom + Windows serial test.** Cuts CI runner
+  disk pressure by stripping debug info from test binaries
+  (`CARGO_PROFILE_DEV_DEBUG=0`, `CARGO_PROFILE_TEST_DEBUG=0`) and
+  serialises the Windows `cargo test` lane (`--test-threads=1`). This
+  unblocks the workspace test crate from exhausting the Windows
+  runner's `C:` drive partway through; combined with PR #27's real L28
+  fix it lets every required platform stay green on full `cargo test
+  --workspace` runs.
+- **PR #23 — `mty check --json` structured result document.** Adds a
+  stable JSON envelope to `mty check`, replacing the
+  stringly-formatted check output for agent callers. 43 new tests
+  cover happy-path, multi-diagnostic, and error-shape coverage; the
+  envelope shape is pinned through `crates/mty-cli/tests/check_json`
+  so future structured-result changes ship a typed diff.
+- **PR #24 — `scripts/test-like-gha.sh` local CI-mimic + pre-push
+  opt-in.** Future agents (and the developer machine) can now
+  reproduce the GHA `CARGO_PROFILE_DEV_DEBUG=0 /
+  CARGO_PROFILE_TEST_DEBUG=0` envs locally, so codegen bugs that only
+  surface under stripped-debug profiles (exactly the class PR #27
+  fixes) are caught before push instead of after CI.
+- **PR #25 — Native `std.fs` JIT/AOT + surface broaden.** Closes the
+  marquee v0.44 carry-forward (**L18 P1**): `std.fs.*` calls on the
+  default `mty run` (Cranelift JIT) and `mty build` paths now reach
+  the runtime directly instead of forcing the interpreter fallback.
+  Adds 11 new runtime ABI symbols
+  (`mty_runtime_fs_{read,read_to_string,read_dir,write,write_string,append,exists,metadata,create_dir_all,remove_file,remove_dir_all}`),
+  matching the existing capability gate (`MT4001`) at typeck. The
+  hosted dispatcher and aliasing from v0.44 stay so generated apps
+  see the same surface from either backend. Mighty IDE's file-I/O
+  shim becomes droppable as a follow-up.
+- **PR #26 — Formatter rollout for `fn` / `struct` / `enum` / `type`
+  decls.** Extends the syntax-aware item formatter beyond top-level
+  `const` (v0.43 L26) to function, struct, enum, and type-alias
+  declarations. Emit-identical against the 67-file `.mty` corpus, so
+  the rollout reformats nothing it does not have a regression test
+  for.
+- **PR #27 — Actually fix L28 codegen (debug=0 SEGV).** Corrects the
+  v0.42 T1 attribution: `Vec[T]` is an opaque prelude ADT registered
+  as `Layout::scalar(PTR_BYTES)`, but `crate::aggregate::is_aggregate`
+  was returning `true` for any `IrTy::Adt`, sending `let mut v = v0`
+  and `let mut v = arg` through the aggregate-Copy memcpy path. That
+  copied 8 bytes of `Vec`'s 32-byte runtime header into an 8-byte
+  slot and re-bound the dest Variable to the truncated slot, dangling
+  the `cap`/`data`/`elem_size` fields when the helper returned. Under
+  the default `[profile.dev]` (`opt-level=0 debug=2`) the OOB stores
+  happened to land on Rust frame bytes that the JIT didn't touch
+  before the readback; under PR #22's `CARGO_PROFILE_DEV_DEBUG=0` —
+  which mirrors GHA — the bytes were overwritten and the JIT SEGV'd
+  (`STATUS_ACCESS_VIOLATION`). Fix: `is_opaque_adt` short-circuit in
+  `lower_assign`'s aggregate-Copy/Move branch, just `def_var` the
+  pointer through, matching what the LLVM backend already does. Both
+  v0.42 ignored Linux/macOS L28 branches unignored; two new
+  pinpoint regressions guard the rebind path.
 
-## Candidate tracks
+## Corrections
 
-- **Native capability ABI:** move `std.fs` beyond interpreter fallback
-  for JIT/AOT output while preserving capability checks and clear
-  diagnostics. **T1 IN FLIGHT (codex/v045-fs-native).**
-- **Formatter rollout:** expand syntax-aware formatting from safe
-  top-level `const` items into more item kinds with regression tests
-  for comments and whitespace preservation.
-- **Agent command surfaces:** prefer structured result values over
-  sentinel strings and mirrored IDs in CLI, LSP, and runtime control
-  paths.
-- **Release hygiene:** keep README, changelog, release notes, and
-  `mty --version` aligned before every tag.
+- **L28 was not actually fixed by v0.41 T3 / v0.42 T1.** Both releases
+  documented an L28 closure that was, in reality, an artefact of the
+  default `[profile.dev]` debug=2 metadata. The real codegen bug —
+  opaque-ADT use-Copy memcpy truncation — survived to v0.45 and is
+  closed only by PR #27. The v0.45 lessons doc has been updated to
+  call this out so future work doesn't trust the prior attribution.
+- **v0.44 release notes attributed v0.42's GHA failures to "disk
+  exhaustion".** That was a misattribution. Some runs did hit disk
+  pressure, but the underlying recurring red was the real L28 SEGV
+  exposed by debug=0 test binaries. PR #22 (debug=0 + serial Windows)
+  + PR #27 (the actual codegen fix) together close that loop, with
+  PR #24 making the failure mode locally reproducible going forward.
 
-## In flight — T1 native std.fs
+## Validation
 
-PR `codex/v045-fs-native` ships the marquee fix: every `std.fs.*`
-method now lowers to a dedicated runtime ABI symbol on the cranelift
-JIT/AOT and LLVM backends, so generated CLIs touch disk under
-`mty build` without a Rust shim.
+- All six PRs (#22, #23, #24, #25, #26, #27) passed required CI
+  checks before merge.
+- Main CI passed on the v0.45.0 merge commit across the six required
+  gates: `test`, `test-minimal`, `msrv`, `clippy-strict`, `bench`,
+  `security`.
+- The `v0.45.0` Release workflow completed across the 5-platform
+  matrix and published platform binaries plus the conformance kit.
+  The conformance-kit double-upload trap patched in
+  commit `2457b47` is no longer load-bearing — `release.yml` ships a
+  single conformance-kit upload per tag.
+- `main` stayed protected; admin merge was used only to move green
+  PRs through branch rules, matching v0.44's policy.
 
-New runtime ABI surface (registered in
-`mty_runtime::codegen_abi::symbol_table` and declared as cranelift /
-LLVM imports):
+## Carry-forward priorities
 
-| Symbol                              | Shape                                        |
-|-------------------------------------|----------------------------------------------|
-| `mty_runtime_fs_read`               | `(path_ptr, path_len, dst_24B_slot)`         |
-| `mty_runtime_fs_read_to_string`     | `(path_ptr, path_len, dst_24B_slot)`         |
-| `mty_runtime_fs_read_dir`           | `(path_ptr, path_len, dst_24B_slot)`         |
-| `mty_runtime_fs_write`              | `(path, data) -> i32 (1=ok, -errno)`         |
-| `mty_runtime_fs_write_string`       | `(path, str) -> i32`                         |
-| `mty_runtime_fs_append`             | `(path, data) -> i32` (NEW alias)            |
-| `mty_runtime_fs_exists`             | `(path) -> i32 (1/0)`                        |
-| `mty_runtime_fs_metadata`           | `(path, dst_24B_slot) -> i32`                |
-| `mty_runtime_fs_create_dir_all`     | `(path) -> i32`                              |
-| `mty_runtime_fs_remove_file`        | `(path) -> i32`                              |
-| `mty_runtime_fs_remove_dir_all`     | `(path) -> i32`                              |
-
-Read/read_dir slot layout: `(ptr@+0, len@+8, ok_flag@+16)`. Metadata
-slot layout: `(size:u64@+0, mtime_ms:i64@+8, is_file:i8@+16,
-is_dir:i8@+17)`.
-
-Capability check stays compile-time. `pub fn` callers missing
-`effect fs` still trip MT4001 at typeck before the codegen runs.
-
-## Validation plan
-
-- Keep full CI green before every release tag.
-- Add focused smoke tests for each native capability ABI expansion.
-- Keep Mighty IDE lessons as the priority source for release-gate
-  fixes.
+- Rework `examples/34_taint_untaint.mty` so the `std.fs.write`
+  destinations are per-run tempdirs, then re-bump the
+  `examples_passing_floor_holds` floor to 28.
+- Continue broadening the formatter rollout — `impl` blocks,
+  agents, protocols, and trait declarations are the next safe
+  layers.
+- Drop the Mighty IDE's file-I/O shim now that `std.fs` works
+  natively under `mty build`/`mty run`.
+- Continue the structured-result push past `mty check --json` into
+  the remaining scalar-ABI command paths (`mty fmt`, `mty find`,
+  `mty fix`).


### PR DESCRIPTION
## Summary

v0.45.0 — native std.fs unblocks shim-less Mighty apps + real L28 codegen fix.

Brings together the 6 v0.45 PRs already merged to main with the version bump + RELEASE-v0.45.md + CHANGELOG + README updates.

## Test plan
- [x] Pre-push hook (fmt + clippy + mty fmt --check on 67 files) passed locally
- [x] All 6 constituent PRs (#22, #23, #24, #25, #26, #27) merged to main with CI green
- [x] v0.45.0 tag created and pushed