### PR TITLE
v0.46: (ptr, len) FFI for Mighty strings (L52)

### DIFF
--- a/crates/mty-codegen-cranelift/src/abi.rs
+++ b/crates/mty-codegen-cranelift/src/abi.rs
@@ -182,6 +182,14 @@ pub fn classify_aggregate_return(ret: &IrTy, adts: &[AdtRef]) -> AggregateReturn
 /// Returns the `Signature` paired with the classification so the
 /// call-site lowerer can drive slot setup, sret arg insertion, and
 /// per-register result store.
+///
+/// v0.46 T3 (L52 fix) — Mighty `Str` / `String` params expand to a
+/// `(const char*, size_t)` pair (two i64s at the ABI level). The C
+/// side declares `void f(int64_t handle, const char* path_ptr,
+/// size_t path_len)` and reads `path_len` bytes from `path_ptr`. The
+/// bytes are owned by the Mighty caller — the C side must not store
+/// the pointer past the call. See `docs/internals/extern-c-matrix.md`
+/// "Str slice (ptr, len) FFI" section.
 pub fn build_extern_signature(
     triple: &Triple,
     params: &[IrTy],
@@ -224,9 +232,25 @@ pub fn build_extern_signature(
         if matches!(p, IrTy::Unit | IrTy::Never) {
             continue;
         }
+        // v0.46 T3 — Str / String at an extern-c param slot expands to
+        // a (ptr, len) pair. Each half rides a single i64 register;
+        // the C signature has two consecutive args (`const char *p`,
+        // `size_t n`). Caller (lower_call) pushes both halves in this
+        // same order via `string_pair`.
+        if matches!(p, IrTy::Str | IrTy::String) {
+            sig.params.push(AbiParam::new(ct::I64)); // ptr
+            sig.params.push(AbiParam::new(ct::I64)); // len
+            continue;
+        }
         sig.params.push(AbiParam::new(cl_ty_for(p)));
     }
     (sig, kind)
+}
+
+/// v0.46 T3 — true iff `p` is a Mighty Str/String param that should
+/// be expanded into a (ptr, len) pair at the extern-c ABI boundary.
+pub fn is_str_slice_param(p: &IrTy) -> bool {
+    matches!(p, IrTy::Str | IrTy::String)
 }
 
 #[cfg(test)]
@@ -313,6 +337,90 @@ mod tests {
             cl_ty_for_variadic(&IrTy::Int(IntKind::U64)),
             (ct::I64, true)
         );
+    }
+
+    #[test]
+    fn extern_signature_expands_str_to_ptr_len_pair() {
+        // v0.46 T3 — `extern c fn foo(s: Str) -> I32` should produce a
+        // 2-param signature: (i64 ptr, i64 len) -> i32. No aggregate-
+        // return work, so the kind is `None`.
+        let (sig, kind) =
+            build_extern_signature(&Triple::host(), &[IrTy::Str], &IrTy::Int(IntKind::I32), &[]);
+        assert_eq!(kind, AggregateReturnKind::None);
+        assert_eq!(sig.params.len(), 2, "Str expands to (ptr, len)");
+        assert_eq!(sig.params[0].value_type, ct::I64);
+        assert_eq!(sig.params[1].value_type, ct::I64);
+        assert_eq!(sig.returns.len(), 1);
+        assert_eq!(sig.returns[0].value_type, ct::I32);
+    }
+
+    #[test]
+    fn extern_signature_expands_string_too() {
+        // `String` (owned Mighty heap string) takes the same (ptr, len)
+        // expansion as `Str`. Same ABI shape — the ownership flavor is
+        // not visible at the FFI boundary.
+        let (sig, _) = build_extern_signature(&Triple::host(), &[IrTy::String], &IrTy::Unit, &[]);
+        assert_eq!(sig.params.len(), 2);
+        assert_eq!(sig.params[0].value_type, ct::I64);
+        assert_eq!(sig.params[1].value_type, ct::I64);
+    }
+
+    #[test]
+    fn extern_signature_str_alongside_scalar() {
+        // (I64 handle, Str path) — IDE's prompted-command shape. Three
+        // ABI slots: (handle:i64, ptr:i64, len:i64).
+        let (sig, _) = build_extern_signature(
+            &Triple::host(),
+            &[IrTy::Int(IntKind::I64), IrTy::Str],
+            &IrTy::Unit,
+            &[],
+        );
+        assert_eq!(sig.params.len(), 3);
+        assert_eq!(sig.params[0].value_type, ct::I64);
+        assert_eq!(sig.params[1].value_type, ct::I64);
+        assert_eq!(sig.params[2].value_type, ct::I64);
+    }
+
+    #[test]
+    fn extern_signature_two_strs_expand_independently() {
+        // Each Str gets its own (ptr, len). Two Str args = four i64
+        // slots, not three (no merging).
+        let (sig, _) = build_extern_signature(
+            &Triple::host(),
+            &[IrTy::Str, IrTy::Str],
+            &IrTy::Int(IntKind::I32),
+            &[],
+        );
+        assert_eq!(sig.params.len(), 4);
+    }
+
+    #[test]
+    fn extern_signature_str_interleaved_with_i32() {
+        // (Str, I32, Str) — 2 + 1 + 2 = 5 slots, in order.
+        let (sig, _) = build_extern_signature(
+            &Triple::host(),
+            &[IrTy::Str, IrTy::Int(IntKind::I32), IrTy::Str],
+            &IrTy::Unit,
+            &[],
+        );
+        assert_eq!(sig.params.len(), 5);
+        assert_eq!(sig.params[0].value_type, ct::I64); // a.ptr
+        assert_eq!(sig.params[1].value_type, ct::I64); // a.len
+        assert_eq!(sig.params[2].value_type, ct::I32); // flags
+        assert_eq!(sig.params[3].value_type, ct::I64); // b.ptr
+        assert_eq!(sig.params[4].value_type, ct::I64); // b.len
+    }
+
+    #[test]
+    fn is_str_slice_param_pinned() {
+        assert!(is_str_slice_param(&IrTy::Str));
+        assert!(is_str_slice_param(&IrTy::String));
+        assert!(!is_str_slice_param(&IrTy::Int(IntKind::I64)));
+        assert!(!is_str_slice_param(&IrTy::Bool));
+        assert!(!is_str_slice_param(&IrTy::Bytes));
+        assert!(!is_str_slice_param(&IrTy::RawPtr(Box::new(IrTy::Int(
+            IntKind::U8
+        )))));
     }
 
     #[test]

--- a/crates/mty-codegen-cranelift/src/lower.rs
+++ b/crates/mty-codegen-cranelift/src/lower.rs
@@ -2351,6 +2351,17 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
                     .get(callee_id)
                     .map(|b| b.is_variadic)
                     .unwrap_or(false);
+                // v0.46 T3 (L52 fix) — extern-c callees expand Mighty
+                // Str/String params into (ptr, len) pairs at the ABI
+                // boundary. See `abi::build_extern_signature`. We track
+                // this here so the fixed-arg lowering loop below can
+                // push two i64 values for each Str/String slot.
+                let is_extern_c_callee = self
+                    .prog
+                    .extern_bindings
+                    .get(callee_id)
+                    .map(|b| b.abi == "c")
+                    .unwrap_or(false);
                 // v0.38 Track T3 — returned-struct classification for the
                 // call site. Drives slot allocation, sret arg insertion,
                 // and per-register result store. Non-aggregate callees
@@ -2446,9 +2457,20 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
                     None
                 };
                 for va in &visible[..fixed_count] {
+                    let want_ty = callee_param_tys_mut.remove(0);
+                    // v0.46 T3 — Str/String at an extern-c param slot
+                    // expands to (ptr, len). Pull both halves from the
+                    // Str aggregate via `string_pair` and push them in
+                    // the same order the extern signature expects (see
+                    // `abi::build_extern_signature`).
+                    if is_extern_c_callee && crate::abi::is_str_slice_param(&want_ty) {
+                        let (ptr, len) = self.string_pair(va.op)?;
+                        arg_vals.push(ptr);
+                        arg_vals.push(len);
+                        continue;
+                    }
                     let v = self.eval_operand(va.op)?;
                     let src_ty = self.operand_ir_ty(va.op);
-                    let want_ty = callee_param_tys_mut.remove(0);
                     let want = if is_aggregate(&want_ty) {
                         ct::I64
                     } else {
@@ -2459,6 +2481,18 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
                 }
                 while !callee_param_tys_mut.is_empty() {
                     let t = callee_param_tys_mut.remove(0);
+                    // v0.46 T3 — pad an unfilled Str/String slot at an
+                    // extern-c callee with two zero i64s (ptr=NULL,
+                    // len=0). Matches the signature's two-slot
+                    // expansion so cranelift doesn't see an arity
+                    // mismatch.
+                    if is_extern_c_callee && crate::abi::is_str_slice_param(&t) {
+                        let z = self.b.ins().iconst(ct::I64, 0);
+                        arg_vals.push(z);
+                        let z2 = self.b.ins().iconst(ct::I64, 0);
+                        arg_vals.push(z2);
+                        continue;
+                    }
                     let want = if is_aggregate(&t) {
                         ct::I64
                     } else {
@@ -2543,6 +2577,15 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
                         sig.returns.push(AbiParam::new(cl_ty_for(&callee_ret_ty)));
                     }
                     for t in &callee_param_tys {
+                        // v0.46 T3 — Str/String at an extern-c fixed
+                        // param slot expands to (ptr, len). Mirror
+                        // `build_extern_signature` here so the per-call
+                        // variadic signature has the same shape.
+                        if crate::abi::is_str_slice_param(t) {
+                            sig.params.push(AbiParam::new(ct::I64));
+                            sig.params.push(AbiParam::new(ct::I64));
+                            continue;
+                        }
                         let want = if is_aggregate(t) {
                             ct::I64
                         } else {

--- a/crates/mty-codegen-cranelift/tests/ffi_str_slice_v046_t3.rs
+++ b/crates/mty-codegen-cranelift/tests/ffi_str_slice_v046_t3.rs
@@ -1,0 +1,219 @@
+//! v0.46 Track T3 — cranelift backend pins for the (ptr, len) FFI
+//! lowering of Mighty `Str` / `String` at extern-c param slots.
+//!
+//! L52 fix. The codegen now emits TWO ABI args at the call site for
+//! every Str / String param of an `extern c` fn: the ptr-half and the
+//! byte-len half. This file pins object-level shapes only — the full
+//! link + run is exercised by the matrix integration test
+//! `crates/mty-driver/tests/extern_c_matrix.rs::row_12_*`.
+//!
+//! The assertions stay at the object level (extern symbol references,
+//! emitted main) rather than the CLIF level because CLIF text is a
+//! cranelift-internal artifact that drifts across upgrades. Object
+//! symbols are stable.
+
+use mty_ast::AstNode;
+use mty_codegen_cranelift::compile_object;
+use mty_ir::lower_package;
+use mty_syntax::parse;
+use object::read::{Object as _, ObjectSymbol as _};
+
+fn lower_to_sir(src: &str, src_id: &str) -> mty_ir::Program {
+    let parsed = parse(src);
+    assert!(
+        parsed.errors.is_empty(),
+        "{src_id}: parse errors: {:?}",
+        parsed.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+    let file = mty_ast::File::cast(mty_syntax::SyntaxNode::new_root(parsed.green))
+        .unwrap_or_else(|| panic!("{src_id}: FILE root not produced"));
+    let (pkg, lower_diags) = mty_hir::lower::LoweringCtx::new().lower_file(file);
+    if let Some(d) = lower_diags
+        .iter()
+        .find(|d| matches!(d.severity, mty_diagnostics::Severity::Error))
+    {
+        panic!(
+            "{src_id}: lower error MT{:04}: {}",
+            d.code.0, d.primary.message
+        );
+    }
+    let typed = mty_types::check_package_typed(&pkg);
+    if let Some(d) = typed
+        .diagnostics
+        .iter()
+        .find(|d| matches!(d.severity, mty_diagnostics::Severity::Error))
+    {
+        panic!(
+            "{src_id}: typeck error MT{:04}: {}",
+            d.code.0, d.primary.message
+        );
+    }
+    lower_package(&pkg, &typed)
+}
+
+fn compile_to_object_bytes(src: &str, src_id: &str) -> Vec<u8> {
+    let prog = lower_to_sir(src, src_id);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let obj_path = tmp.path().join(format!("{src_id}.o"));
+    compile_object(&prog, &obj_path).unwrap_or_else(|e| panic!("[{src_id}] compile_object: {e:?}"));
+    std::fs::read(&obj_path).expect("read object")
+}
+
+fn object_has_extern_symbol_ref(bytes: &[u8], wanted: &str) -> bool {
+    let parsed = object::read::File::parse(bytes).expect("object parse");
+    for sym in parsed.symbols() {
+        if let Ok(name) = sym.name() {
+            if name == wanted || name == format!("_{}", wanted) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// ---------- Str at extern-c param slot ----------
+
+#[test]
+fn str_slice_single_arg_compiles() {
+    // Simplest shape: one Str param, no return. Pins that the
+    // signature builder + call-site lowering both accept Str and emit
+    // the (ptr, len) expansion without a verifier failure.
+    let src = r#"
+extern c {
+  fn ffi_take_str(s: Str) -> Unit
+}
+
+fn main() {
+  ffi_take_str("hello")
+}
+"#;
+    let bytes = compile_to_object_bytes(src, "str_slice_single_arg");
+    assert!(
+        object_has_extern_symbol_ref(&bytes, "ffi_take_str"),
+        "expected extern reference to `ffi_take_str` in emitted object"
+    );
+}
+
+#[test]
+fn str_slice_with_scalar_prefix_compiles() {
+    // (handle: I64, s: Str) — the IDE's prompted-command shape. Pins
+    // that the (ptr, len) expansion slots in alongside a scalar arg
+    // without shifting the ABI ordering.
+    let src = r#"
+extern c {
+  fn mui_file_rename(handle: I64, path: Str) -> Unit
+}
+
+fn main() {
+  let h: I64 = 1
+  mui_file_rename(h, "newname.txt")
+}
+"#;
+    let bytes = compile_to_object_bytes(src, "str_slice_scalar_prefix");
+    assert!(object_has_extern_symbol_ref(&bytes, "mui_file_rename"));
+}
+
+#[test]
+fn str_slice_returns_i32() {
+    // Str arg + scalar return — pins that the return-value plumbing
+    // still works when the param ABI shape doubled.
+    let src = r#"
+extern c {
+  fn ffi_count(s: Str) -> I32
+}
+
+fn main() {
+  let n = ffi_count("hello-world")
+  let _ = n
+}
+"#;
+    let bytes = compile_to_object_bytes(src, "str_slice_returns_i32");
+    assert!(object_has_extern_symbol_ref(&bytes, "ffi_count"));
+}
+
+#[test]
+fn str_slice_two_str_args_compiles() {
+    // Two Str slots — each independently expanded to (ptr, len). Pins
+    // that the slot-doubling isn't a once-only special case.
+    let src = r#"
+extern c {
+  fn ffi_two(a: Str, b: Str) -> I32
+}
+
+fn main() {
+  let _ = ffi_two("first", "second")
+}
+"#;
+    let bytes = compile_to_object_bytes(src, "str_slice_two_args");
+    assert!(object_has_extern_symbol_ref(&bytes, "ffi_two"));
+}
+
+#[test]
+fn str_slice_empty_literal_compiles() {
+    // Empty literal — pins that the lowering produces a valid (ptr,
+    // len=0) pair even when the Str literal has zero bytes.
+    let src = r#"
+extern c {
+  fn ffi_take(s: Str) -> Unit
+}
+
+fn main() {
+  ffi_take("")
+}
+"#;
+    let bytes = compile_to_object_bytes(src, "str_slice_empty");
+    assert!(object_has_extern_symbol_ref(&bytes, "ffi_take"));
+}
+
+#[test]
+fn str_slice_interleaved_with_scalar_compiles() {
+    // (Str, I32, Str) — Str slots not contiguous. Pins that the
+    // signature builder walks params in order and expands only the
+    // Str slots, not the I32 between them.
+    let src = r#"
+extern c {
+  fn ffi_mixed(a: Str, count: I32, b: Str) -> Unit
+}
+
+fn main() {
+  ffi_mixed("first", 3, "second")
+}
+"#;
+    let bytes = compile_to_object_bytes(src, "str_slice_interleaved");
+    assert!(object_has_extern_symbol_ref(&bytes, "ffi_mixed"));
+}
+
+#[test]
+fn str_slice_with_pointer_and_str_compiles() {
+    // (Str, *U8) — pins that the existing *U8 coercion (Str -> *U8
+    // for null-terminated C strings) and the new Str-slice expansion
+    // can co-exist on the same call.
+    let src = r#"
+extern c {
+  fn ffi_blend(slice: Str, cstr: *U8) -> I32
+}
+
+fn main() {
+  let _ = ffi_blend("payload", "cstring")
+}
+"#;
+    let bytes = compile_to_object_bytes(src, "str_slice_blend");
+    assert!(object_has_extern_symbol_ref(&bytes, "ffi_blend"));
+}
+
+#[test]
+fn str_slice_three_strs_compiles() {
+    // L52's worst-case dispatcher shape — three Str args in a row,
+    // all expanded.
+    let src = r#"
+extern c {
+  fn ffi_three(a: Str, b: Str, c: Str) -> I32
+}
+
+fn main() {
+  let _ = ffi_three("one", "two", "three")
+}
+"#;
+    let bytes = compile_to_object_bytes(src, "str_slice_three");
+    assert!(object_has_extern_symbol_ref(&bytes, "ffi_three"));
+}

--- a/crates/mty-codegen-llvm/src/lower.rs
+++ b/crates/mty-codegen-llvm/src/lower.rs
@@ -372,18 +372,30 @@ impl<'ctx, 'a, 'b> ProgramLowerer<'ctx, 'a, 'b> {
     }
 
     fn fn_type_of(&self, f: &Function) -> inkwell::types::FunctionType<'ctx> {
-        let param_tys: Vec<BasicMetadataTypeEnum<'ctx>> = f
-            .params
-            .iter()
-            .filter_map(|p| {
-                let t = &f.locals[p.0 as usize].ty;
-                if matches!(t, IrTy::Unit | IrTy::Never) {
-                    None
-                } else {
-                    Some(self.llvm_ty(t).into())
-                }
-            })
-            .collect();
+        // v0.46 T3 — extern-c fns expand Str/String params into
+        // (ptr, len) i64 pairs at the ABI boundary. See
+        // `docs/internals/extern-c-matrix.md` "Str slice (ptr, len)
+        // FFI" section.
+        let is_extern_c = self
+            .prog
+            .extern_bindings
+            .get(&f.id)
+            .map(|b| b.abi == "c")
+            .unwrap_or(false);
+        let mut param_tys: Vec<BasicMetadataTypeEnum<'ctx>> = Vec::with_capacity(f.params.len());
+        for p in &f.params {
+            let t = &f.locals[p.0 as usize].ty;
+            if matches!(t, IrTy::Unit | IrTy::Never) {
+                continue;
+            }
+            if is_extern_c && matches!(t, IrTy::Str | IrTy::String) {
+                let i64ty: BasicMetadataTypeEnum<'ctx> = self.i64_ty().into();
+                param_tys.push(i64ty); // ptr
+                param_tys.push(i64ty); // len
+                continue;
+            }
+            param_tys.push(self.llvm_ty(t).into());
+        }
         if matches!(f.ret_ty, IrTy::Unit | IrTy::Never) {
             self.ctx.void_type().fn_type(&param_tys, false)
         } else {
@@ -1215,6 +1227,15 @@ impl<'p, 'ctx, 'a, 'b> FnLowerer<'p, 'ctx, 'a, 'b> {
                     LlvmError::Module(format!("call to undeclared {:?}", callee_id))
                 })?;
                 let callee_fn = self.pl.prog.fn_by_id(*callee_id);
+                // v0.46 T3 — extern-c fns expand Str/String to (ptr, len).
+                // Detect here so the arg-pushing loop knows to split.
+                let is_extern_c = self
+                    .pl
+                    .prog
+                    .extern_bindings
+                    .get(callee_id)
+                    .map(|b| b.abi == "c")
+                    .unwrap_or(false);
                 let mut arg_vals: Vec<inkwell::values::BasicMetadataValueEnum<'ctx>> = Vec::new();
                 let mut callee_param_tys: Vec<IrTy> = callee_fn
                     .params
@@ -1223,8 +1244,9 @@ impl<'p, 'ctx, 'a, 'b> FnLowerer<'p, 'ctx, 'a, 'b> {
                     .filter(|t| !matches!(t, IrTy::Unit | IrTy::Never))
                     .collect();
                 let expected = callee_param_tys.len();
+                let mut consumed_param_slots = 0;
                 for a in args {
-                    if arg_vals.len() >= expected {
+                    if consumed_param_slots >= expected {
                         break;
                     }
                     if matches!(a, Operand::Const(Const::Unit)) {
@@ -1240,6 +1262,21 @@ impl<'p, 'ctx, 'a, 'b> FnLowerer<'p, 'ctx, 'a, 'b> {
                     } else {
                         None
                     };
+                    consumed_param_slots += 1;
+                    // v0.46 T3 — Str/String at an extern-c param slot
+                    // expands to (ptr, len). Pull both halves and
+                    // push them in this order; matches `fn_type_of`'s
+                    // signature expansion.
+                    if is_extern_c
+                        && want_ty
+                            .as_ref()
+                            .is_some_and(|t| matches!(t, IrTy::Str | IrTy::String))
+                    {
+                        let (ptr, len) = self.string_pair(a)?;
+                        arg_vals.push(ptr.into());
+                        arg_vals.push(len.into());
+                        continue;
+                    }
                     let coerced = if let Some(t) = &want_ty {
                         let lt = self.pl.llvm_ty(t);
                         self.coerce_with_src(v, lt, src_ty.as_ref())
@@ -1251,6 +1288,13 @@ impl<'p, 'ctx, 'a, 'b> FnLowerer<'p, 'ctx, 'a, 'b> {
                 // Pad missing args with zero defaults.
                 while !callee_param_tys.is_empty() {
                     let t = callee_param_tys.remove(0);
+                    if is_extern_c && matches!(t, IrTy::Str | IrTy::String) {
+                        let z1: BasicValueEnum<'ctx> = self.pl.i64_ty().const_zero().into();
+                        let z2: BasicValueEnum<'ctx> = self.pl.i64_ty().const_zero().into();
+                        arg_vals.push(z1.into());
+                        arg_vals.push(z2.into());
+                        continue;
+                    }
                     let lt = self.pl.llvm_ty(&t);
                     let v: BasicValueEnum<'ctx> = match lt {
                         BasicTypeEnum::IntType(it) => it.const_zero().into(),

--- a/crates/mty-driver/tests/extern_c_matrix.rs
+++ b/crates/mty-driver/tests/extern_c_matrix.rs
@@ -491,3 +491,34 @@ fn row_11_fn_ptr() {
     p.push("row_11_fn_ptr");
     run_row(&p, Some("row11:"));
 }
+
+#[test]
+fn row_12_str_slice_ascii() {
+    // v0.46 T3 (L52 fix): `extern c fn f(s: Str)` expands to
+    // `void f(const char*, size_t)` at the call site. The Mighty
+    // source `mty_row12_echo("hello-from-mighty")` passes the literal's
+    // ptr and 17 (the byte count) — the C side prints the echo'd bytes
+    // and the marker line lands in stdout.
+    let mut p = matrix_root();
+    p.push("row_12_str_slice");
+    run_row(&p, Some("row12:echo='hello-from-mighty',len=17"));
+}
+
+#[test]
+fn row_12_str_slice_empty() {
+    // Empty string round trip — len=0, ptr arg is irrelevant on the C
+    // side. Pins that the call still survives the trip without
+    // dereferencing whatever the codegen picks as the ptr operand.
+    let mut p = matrix_root();
+    p.push("row_12_str_slice");
+    run_row(&p, Some("row12:empty,len=0"));
+}
+
+#[test]
+fn row_12_str_slice_utf8() {
+    // UTF-8 multi-byte round trip — pins that `len` is the BYTE count,
+    // not the codepoint count. "héllo" is 6 bytes.
+    let mut p = matrix_root();
+    p.push("row_12_str_slice");
+    run_row(&p, Some("row12:utf8='héllo',bytes=6"));
+}

--- a/docs/internals/extern-c-matrix.md
+++ b/docs/internals/extern-c-matrix.md
@@ -1,4 +1,4 @@
-# Extern C signature matrix (v0.36 T2 + v0.37 T3 + v0.38 T3)
+# Extern C signature matrix (v0.36 T2 + v0.37 T3 + v0.38 T3 + v0.46 T3)
 
 This document is the human-readable mirror of `tests/extern_c_matrix/`.
 It pins which C-ABI shapes Mighty can call end-to-end today, what the
@@ -14,6 +14,13 @@ shapes are deferred to v0.38.
 > plus adds the `#[ffi_nul_ok]` attribute as a metadata-only marker
 > for the Str→*U8 coercion's fast path. See the **v0.38 surfaces**
 > section.
+
+> v0.46 T3 adds row 12 — Mighty `Str` / `String` at an extern-c param
+> slot now lowers to an ABI `(const char* ptr, size_t len)` pair. The
+> Mighty source spells the call with a single Str arg; the cranelift
+> backend expands it into two i64 ABI args at the call site. No more
+> char-by-char staging through scalar helpers (L52). See the
+> **v0.46 T3 — (ptr, len) Str slice FFI** section.
 
 Audience: anyone shipping an FFI Mighty app — first-class downstream
 consumers are the native-IDE track (`C:\Users\ihass\mighty-ide`) and
@@ -148,6 +155,7 @@ matrix test still proves the .a is reachable.
 | 10 | `extern c fn foo(s: *mut Str) -> usize` (caller-owned buf) | works (wrapper) | The classic `snprintf` shape. Wrapper stays because Mighty doesn't yet expose a mutable `Str` buffer surface (you'd need a `[U8; N]` and pass `&mut buf[0]`, which v0.37 T3 partially covers — full coverage is v0.38). |
 | 11 | `extern c fn foo(cb: fn(i32) -> i32)` | works (v0.38 direct) | ~~wrapper-pattern~~ — v0.38 T3 ships the function-pointer surface. The Mighty parser already accepts `fn(T1, T2) -> R` as a type. Typeck unifies the Mighty fn's resolved `TyData::Fn { params, ret }` against the param's declared `Fn` type. The cranelift backend lowers a `Const::FnPtr(FnRef::User(fid))` operand via `func_addr` against the local fn's `Linkage::Local` declaration; the linker resolves the address at final-link time. Builtin fn pointers (`log`, `panic`) are not addressable through this surface — use a plain Mighty fn for FFI callbacks. |
 | 12 | Variadic call (`printf(fmt, …)`) | works (v0.38 T2) | `extern c fn printf(fmt: *U8, ...) -> I32` parses + typechecks (v0.37 T6) **and** end-to-end calls with extra varargs lower through a per-call `ir::Signature` + `call_indirect` against `func_addr` of the imported symbol (v0.38 T2). C ABI default promotions applied to extras (`f32→f64`, `i8/i16→i32`, `u8/u16→u32`, `bool/char→i32`). ~~v0.38 follow-up~~ — **v0.38 complete**. Wasm stance unchanged (variadic externs still rejected). |
+| 13 | `extern c fn foo(s: Str) -> I32` (Str slice) | works (v0.46 T3 direct) | Mighty `Str` / `String` at an extern-c param slot expands to `(const char* ptr, size_t len)` at the ABI boundary. Mighty source spells the call with one Str arg; the cranelift backend emits two consecutive i64 args (the ptr-half and the byte-len half from the Str aggregate). Documented + tested in row 12 of `tests/extern_c_matrix/` plus `crates/mty-codegen-cranelift/tests/ffi_str_slice_v046_t3.rs`. See **v0.46 T3** section. |
 
 ## v0.37 ergonomics — the FFI surface is now ergonomic
 
@@ -367,6 +375,167 @@ Implementation details:
 | Tests — typeck                               | `crates/mty-types/tests/ffi_v038_t3.rs` (16 cases)                        |
 | Tests — codegen                              | `crates/mty-codegen-cranelift/tests/ffi_v038_t3.rs` (9 cases)             |
 | Demo                                         | `demos/11_ffi_winit_stub/` (now exercises rows 07 + 11 + nul_ok)          |
+
+## v0.46 T3 — (ptr, len) Str slice FFI (L52 fix)
+
+Mighty `Str` / `String` values are (ptr, len) aggregates internally —
+the ptr-half points at the UTF-8 byte blob (`intern_string`
+null-terminates literals; runtime-built Strs ride a real heap pointer),
+and the len-half is the BYTE count.
+
+Before v0.46 T3 the only path for passing string data across `extern c`
+was the v0.37 `Str → *U8` coercion, which:
+
+1. Required the caller's *param type* to be `*U8` (not `Str`).
+2. Implicitly read the ptr-half only — the C side had to call `strlen`
+   or rely on null-termination to recover the length.
+
+That worked for shapes like `strlen(s)` (row 09), but broke down for
+ANY shape where the C side wanted to handle non-null-terminated bytes,
+dispatch on the byte length first, or avoid the O(n) `strlen` walk.
+L52 documents the IDE's downstream pain: every prompt-driven command
+in `src/main.mty` (`Open`, `New Folder`, `Rename`, `Delete`, …) had to
+copy its query buffer through the Rust shim ONE CODEPOINT AT A TIME via
+`mui_path_push(handle, mui_prompt_char(handle, i))` because there was
+no way to hand a single Mighty string across the FFI boundary.
+
+v0.46 T3 closes the gap with a transparent compiler transform: write
+the Mighty signature with a `Str` (or `String`) param, write the C
+signature with a `(const char* ptr, size_t len)` pair, and the
+cranelift backend bridges the two at the call site.
+
+### Surface — `Str` at an extern-c param slot
+
+```mighty
+extern c {
+  fn mui_file_rename(handle: I64, path: Str) -> Unit
+}
+
+fn main() {
+  let h: I64 = 1
+  mui_file_rename(h, "newname.txt")
+}
+```
+
+The C header declares:
+
+```c
+#include <stddef.h>
+#include <stdint.h>
+
+void mui_file_rename(int64_t handle, const char *path_ptr, size_t path_len);
+```
+
+Each `Str` / `String` param expands to **two consecutive ABI args**:
+
+* `ptr_half`  : `int64_t` carrying the byte-pointer (same shape as
+                `Str → *U8`'s ptr extraction).
+* `len_half`  : `int64_t` (`size_t`) carrying the BYTE count.
+
+The expansion happens uniformly in:
+
+* `mty_codegen_cranelift::abi::build_extern_signature` — the extern
+  signature has the doubled slot count.
+* `mty_codegen_cranelift::lower::lower_call` — at the call site, every
+  `Str`/`String`-typed arg pulls both halves from the Str aggregate
+  via `string_pair` and pushes them in (ptr, len) order.
+* `mty_codegen_llvm::lower::fn_type_of` + `lower_call` — same
+  expansion for the LLVM backend (literal-Str only; dynamic-Str
+  routes through cranelift today).
+
+### Ownership + lifetime contract
+
+* The bytes are **owned by the Mighty caller**. The pointer is live
+  for the duration of the call expression and no longer.
+* The C side **must not store the pointer** in a heap structure or
+  return it through a global — Mighty may free / move / reuse the
+  backing arena after the call returns.
+* The C side **must read at most `len` bytes** from the pointer.
+* `len == 0` is legal; the pointer arg is undefined in that case (the
+  cranelift backend usually passes the literal's symbol address even
+  for `""`, but C must not dereference unless `len > 0`).
+* Multi-byte UTF-8 is preserved as-is; `len` is the BYTE count, NOT
+  the codepoint count.
+
+### Interaction with the v0.37 `Str → *U8` coercion
+
+The two surfaces compose:
+
+| Mighty source | Param type     | Lowering                                                          |
+|---------------|----------------|-------------------------------------------------------------------|
+| `f("hi")`     | `*U8`          | v0.37 — passes one i64 (ptr-half), C reads via `strlen` / nul.   |
+| `f("hi")`     | `Str`/`String` | v0.46 T3 — passes two i64s (ptr, len), C reads exactly `len`.    |
+
+Same Mighty source, different C contract — pick `*U8` when the C side
+is a libc-style nul-terminated function, pick `Str` when you want the
+length up front. Mixed-arg calls (`fn foo(slice: Str, cstr: *U8)`)
+work without ceremony.
+
+### Wasm backend stance
+
+Wasm core doesn't have a 64-bit-style C ABI; the wasm backend treats
+the existing `Rvalue::StrPtr` as a pass-through and an `extern c fn
+foo(s: Str)` call still surfaces a single-arg call to the import. If
+you target wasm and need the byte length too, declare a separate
+`extern js fn foo_len()` and lower per-target. Same stance as
+variadics.
+
+### IDE simplification example
+
+Pre-v0.46 T3 (the L52 staging-loop pattern from `mighty-ide/src/main.mty`):
+
+```mighty
+// Stage the prompt string char-by-char into a shim buffer.
+mui_path_clear(handle)
+let mut i: USize = 0
+while i < mui_prompt_len(handle) {
+  mui_path_push(handle, mui_prompt_char(handle, i))
+  i = i + 1
+}
+// Call the real op against the shim's staged buffer.
+mui_file_rename_active(handle)
+```
+
+Post-v0.46 T3 — direct call, no shim buffer:
+
+```mighty
+extern c {
+  fn mui_file_rename_active(handle: I64, path: Str) -> Unit
+}
+
+// Pull the prompt text into a Mighty String, hand it across as-is.
+let path: String = mui_prompt_text(handle)
+mui_file_rename_active(handle, path)
+```
+
+The shim's C-side `mui_file_rename_active` declaration changes from
+`void mui_file_rename_active(int64_t)` to
+`void mui_file_rename_active(int64_t, const char*, size_t)`; it can
+delete `mui_path_clear` / `mui_path_push` / `mui_prompt_char` / the
+backing per-handle staging buffer. The L52 pattern survives only for
+backwards compatibility with pre-v0.46 callers.
+
+### Where the wiring lives
+
+| Concern                                            | File                                                                          |
+|----------------------------------------------------|-------------------------------------------------------------------------------|
+| Signature expansion (cranelift)                    | `crates/mty-codegen-cranelift/src/abi.rs` (`build_extern_signature`, `is_str_slice_param`) |
+| Call-site Str→(ptr, len) emit (cranelift fixed)    | `crates/mty-codegen-cranelift/src/lower.rs` (`lower_call`, `FnRef::User` arm) |
+| Call-site Str→(ptr, len) emit (cranelift variadic) | `crates/mty-codegen-cranelift/src/lower.rs` (variadic per-call signature)     |
+| Signature expansion (LLVM)                          | `crates/mty-codegen-llvm/src/lower.rs` (`fn_type_of`)                         |
+| Call-site Str→(ptr, len) emit (LLVM)               | `crates/mty-codegen-llvm/src/lower.rs` (`lower_call`)                         |
+| Cranelift object-shape tests (8 cases)              | `crates/mty-codegen-cranelift/tests/ffi_str_slice_v046_t3.rs`                |
+| End-to-end matrix integration (3 cases)            | `crates/mty-driver/tests/extern_c_matrix.rs` (`row_12_*`)                    |
+| Matrix fixture                                      | `tests/extern_c_matrix/row_12_str_slice/{app.mty, impl.c}`                   |
+
+### Unresolved
+
+* **Out-params / mutable buffers** (`mut Vec[U8]` for caller-allocated
+  output buffers) deferred to v0.47. Today the IDE uses fixed shim-
+  side scratch buffers for the C-writes-back pattern; once mutable
+  byte-buffer FFI is in, the shim can vanish too.
+* **String ownership transfer across FFI** (move semantics) is out of
+  scope — the caller-owns model is the safer default.
 
 ## Remaining v0.39 follow-ups
 

--- a/examples/45_ffi_str_slice.mty
+++ b/examples/45_ffi_str_slice.mty
@@ -1,0 +1,84 @@
+// v0.46 T3 — (ptr, len) FFI for Mighty `Str` / `String`.
+//
+// L52 fix. Before v0.46 T3, passing a string across an `extern c`
+// boundary required either (a) the v0.37 `Str → *U8` coercion (loses
+// the byte length; C must call strlen / rely on nul-termination) or
+// (b) a char-by-char staging loop into a shim-side buffer (the IDE's
+// L52 pattern: `mui_path_clear` + `for i in 0..n { mui_path_push }`
+// then call the real op). v0.46 T3 closes both gaps with a transparent
+// compiler transform: write the Mighty signature with a `Str` param,
+// write the C signature with `(const char* ptr, size_t len)`, and
+// every call expands the one Mighty arg into two ABI slots at the
+// call site.
+//
+// Run as a typeck / lowering smoke (no native build needed):
+//
+//   $ mty check examples/45_ffi_str_slice.mty
+//
+// The `_ffi_str_slice_*` symbols are declared but never linked — this
+// example pins the call-site shapes the type checker accepts. The
+// full link + run is exercised by `tests/extern_c_matrix/row_12_*`
+// and `crates/mty-codegen-cranelift/tests/ffi_str_slice_v046_t3.rs`.
+extern c {
+  // Shape 1 — single Str arg. The C declaration is:
+  //   int32_t _ffi_str_slice_echo(const char* ptr, size_t len);
+  // The Mighty caller spells one arg; the codegen emits two.
+  fn _ffi_str_slice_echo(s: Str) -> I32
+
+  // Shape 2 — scalar prefix + Str. The IDE's prompted-command pattern.
+  //   void _ffi_str_slice_rename(int64_t handle,
+  //                              const char* path_ptr, size_t path_len);
+  fn _ffi_str_slice_rename(handle: I64, path: Str) -> Unit
+
+  // Shape 3 — two Strs interleaved with a scalar. Pins that the
+  // (ptr, len) expansion is per-param, not per-call.
+  //   void _ffi_str_slice_blend(const char* a_ptr, size_t a_len,
+  //                             int32_t flags,
+  //                             const char* b_ptr, size_t b_len);
+  fn _ffi_str_slice_blend(a: Str, flags: I32, b: Str) -> Unit
+
+  // Shape 4 — Str alongside the v0.37 *U8 coercion. The two surfaces
+  // compose: Str -> (ptr, len) AND Str literal -> *U8 (nul-terminated)
+  // can land in the same call.
+  //   int32_t _ffi_str_slice_mixed(const char* slice_ptr, size_t slice_len,
+  //                                const char* cstr);
+  fn _ffi_str_slice_mixed(slice: Str, cstr: *U8) -> I32
+}
+
+fn main() {
+  // Direct literal.
+  let n1 = _ffi_str_slice_echo("hello-from-mighty")
+  let _ = n1
+
+  // Empty string — len=0 is legal; C side must not deref.
+  let n2 = _ffi_str_slice_echo("")
+  let _ = n2
+
+  // Multi-byte UTF-8 — `len` is the BYTE count (6 for "héllo"), not
+  // the codepoint count (5).
+  let n3 = _ffi_str_slice_echo("héllo")
+  let _ = n3
+
+  // IDE-shaped prompted command — the v0.46 T3 replacement for the
+  // L52 char-by-char staging loop. Pre-v0.46 this required:
+  //
+  //     mui_path_clear(handle)
+  //     let mut i: USize = 0
+  //     while i < mui_prompt_len(handle) {
+  //       mui_path_push(handle, mui_prompt_char(handle, i))
+  //       i = i + 1
+  //     }
+  //     mui_file_rename_active(handle)
+  //
+  // Post-v0.46 T3 it's one line. The C shim drops its scratch buffer.
+  let handle: I64 = 1
+  _ffi_str_slice_rename(handle, "newname.txt")
+
+  // Two Str slots interleaved with a scalar — each Str gets its own
+  // (ptr, len) pair; the I32 stays a single i32 slot.
+  _ffi_str_slice_blend("first", 7, "second")
+
+  // Composition with v0.37 *U8: a Str-slice arg AND a Str -> *U8
+  // coerced arg in the same call.
+  let _ = _ffi_str_slice_mixed("payload-bytes", "c-style-cstring")
+}

--- a/tests/extern_c_matrix/row_12_str_slice/app.mty
+++ b/tests/extern_c_matrix/row_12_str_slice/app.mty
@@ -1,0 +1,26 @@
+// Row 12: Mighty Str -> C (ptr, len) FFI.
+//
+// v0.46 T3 (L52 fix). The codegen expands each Str / String param at
+// an extern-c call site into two ABI args: a ptr (i64, const char*)
+// and a len (i64, size_t). The Mighty source spells the call exactly
+// like a single-arg call; the codegen handles the split.
+//
+// Replaces the L52 char-by-char `mui_path_push` staging loop pattern.
+
+extern c {
+  fn mty_row12_echo(s: Str) -> I32
+  fn mty_row12_accept_empty(s: Str) -> I32
+  fn mty_row12_utf8(s: Str) -> I32
+}
+
+fn main() {
+  // ASCII round trip.
+  let n1 = mty_row12_echo("hello-from-mighty")
+  let _ = n1
+  // Empty string.
+  let n2 = mty_row12_accept_empty("")
+  let _ = n2
+  // UTF-8: "héllo" is 6 bytes (é = 0xc3 0xa9).
+  let n3 = mty_row12_utf8("héllo")
+  let _ = n3
+}

--- a/tests/extern_c_matrix/row_12_str_slice/impl.c
+++ b/tests/extern_c_matrix/row_12_str_slice/impl.c
@@ -1,0 +1,59 @@
+/*
+ * Row 12: Mighty Str / String -> C (const char* ptr, size_t len).
+ *
+ * v0.46 T3 (L52 fix) — the cranelift backend now expands a Mighty Str
+ * or String at an extern-c param slot into two ABI args (the ptr and
+ * the byte length). The C declaration sees them as a normal pair:
+ *
+ *   void f(int64_t handle, const char* path_ptr, size_t path_len)
+ *
+ * The bytes are owned by the Mighty caller. C must not store the
+ * pointer past the call. See `docs/internals/extern-c-matrix.md`
+ * "Str slice (ptr, len) FFI" section.
+ */
+#include <stddef.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Echo: copy `len` bytes from `ptr` into a stack buffer, NUL-terminate,
+ * print, and return the count. Verifies the C side reads exactly `len`
+ * bytes (not a strlen of a possibly-null-terminated input). */
+int32_t mty_row12_echo(const char *ptr, size_t len) {
+  char buf[256];
+  size_t cap = sizeof(buf) - 1;
+  size_t n = len < cap ? len : cap;
+  if (n && ptr) {
+    memcpy(buf, ptr, n);
+  }
+  buf[n] = '\0';
+  printf("row12:echo='%s',len=%zu\n", buf, len);
+  fflush(stdout);
+  return (int32_t)len;
+}
+
+/* Empty / NULL ptr smoke: the Mighty side passes "" — len must be 0 and
+ * the call must not segfault even if the ptr is whatever the codegen
+ * picks (intern_string still returns a real symbol, but the C contract
+ * is: do not deref unless len > 0). */
+int32_t mty_row12_accept_empty(const char *ptr, size_t len) {
+  (void)ptr;
+  printf("row12:empty,len=%zu\n", len);
+  fflush(stdout);
+  return (int32_t)len;
+}
+
+/* Non-ASCII (multi-byte UTF-8) round trip — confirm len is the BYTE
+ * count, not the codepoint count. "héllo" = 6 bytes (é = 0xc3 0xa9). */
+int32_t mty_row12_utf8(const char *ptr, size_t len) {
+  char buf[256];
+  size_t cap = sizeof(buf) - 1;
+  size_t n = len < cap ? len : cap;
+  if (n && ptr) {
+    memcpy(buf, ptr, n);
+  }
+  buf[n] = '\0';
+  printf("row12:utf8='%s',bytes=%zu\n", buf, len);
+  fflush(stdout);
+  return (int32_t)len;
+}


### PR DESCRIPTION
## Summary

- v0.46 T3 — Mighty `Str` / `String` at an `extern c` param slot now lowers to an ABI `(const char* ptr, size_t len)` pair. The Mighty source spells the call with one Str arg; the cranelift backend expands it into two consecutive i64 ABI args at the call site.
- Closes the L52 staging-loop gap: the IDE's `mui_path_clear` + `for i in 0..n { mui_path_push(handle, mui_prompt_char(handle, i)) }` + call pattern is replaced by a single direct call when the C side declares `void f(int64_t, const char*, size_t)`.
- Composes with v0.37's `Str → *U8` coercion — the C-side param type chooses the shape, same Mighty source. Mixed-arg calls work.

## What ships

- **Cranelift backend**: `abi::build_extern_signature` expands Str/String to two i64 slots; `lower_call` emits (ptr, len) at fixed + variadic prefix sites via `string_pair`. Padding for missing Str slots zero-fills both halves.
- **LLVM backend**: `fn_type_of` + `lower_call` mirror the expansion (literal-Str only; dynamic-Str routes through cranelift).
- **Tests** (all green locally on Windows MSVC):
  - 6 new `mty-codegen-cranelift::abi` unit tests (Str / String / scalar interleave / two-Str / `is_str_slice_param`).
  - 8 new object-level shape tests in `crates/mty-codegen-cranelift/tests/ffi_str_slice_v046_t3.rs` (single arg, scalar prefix, scalar return, two-Str, empty literal, interleaved scalars, blend with v0.37 `*U8` coercion, three-Str dispatcher).
  - 3 new end-to-end matrix integration tests (`row_12_str_slice_{ascii, empty, utf8}`) that link a C fixture against the Mighty binary and assert the marker line in stdout (ASCII round-trip, empty-string `len=0`, UTF-8 `len` is the byte count).
- **Docs**: `docs/internals/extern-c-matrix.md` gets row 13 in the matrix table + a full v0.46 T3 section (surface, ownership / lifetime contract, ABI shape, wasm-backend stance, IDE-side before / after example replacing the L52 staging loop).
- **Example**: `examples/45_ffi_str_slice.mty` — single, scalar-prefix, interleaved, and `*U8`-blend shapes side by side.
- **Matrix fixture**: `tests/extern_c_matrix/row_12_str_slice/{app.mty, impl.c}`.

## References

- L52 — prompt-driven commands still require duplicated char-by-char string staging (P2). Closed by this change.
- L17 — `extern c` could pass ONLY scalars from Mighty-owned data (P0). v0.37 T3 / v0.38 T3 already lifted the wrapper-pattern shapes; v0.46 T3 adds the missing Str / String surface.

## Test plan

- [x] `cargo test -p mty-codegen-cranelift --lib abi` — 15 passed (6 new + 9 existing).
- [x] `cargo test -p mty-codegen-cranelift --test ffi_str_slice_v046_t3` — 8 passed.
- [x] `cargo test -p mty-codegen-cranelift --test ffi_v038_t3` — 9 passed (no regression).
- [x] `cargo test -p mty-driver --test extern_c_matrix` — 14 passed (3 new row_12 + 11 existing rows).
- [x] `cargo test -p mty-types --test ffi_coercions_v037` — 18 passed (no regression).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `mty fmt --check` on 67 known `.mty` paths — clean.
- [x] Local pre-push hook (fmt + clippy + mty fmt) passed in full before push.

## Unresolved (deferred to v0.47)

- Mutable Str / `mut Vec[U8]` for caller-allocated OUT buffers (rows 10 / writeback). Today the IDE uses fixed shim-side scratch buffers for the C-writes-back pattern.
- String ownership transfer across FFI (move semantics). Caller-owns is the safer default.

Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)