### PR TITLE
v0.46: mty build exit code + MTY_LINKER paths (L50)

### DIFF
--- a/crates/mty-cli/src/cmd/build.rs
+++ b/crates/mty-cli/src/cmd/build.rs
@@ -16,6 +16,7 @@ pub fn run(
     no_component: bool,
     wasi: Option<String>,
     world: Option<String>,
+    emit: Option<String>,
 ) -> i32 {
     let src = match fs::read_to_string(path) {
         Ok(s) => s,
@@ -116,17 +117,48 @@ pub fn run(
         BuildTarget::Wasm(t) => build_wasm(src, source_id, &opts, t),
     };
 
+    // v0.46 T2 — `--emit obj` lets CI flows opt into object-only output
+    // (the historic "no linker" success path). Any other value is
+    // rejected up-front so a typo doesn't silently fall through.
+    let emit_obj_only = match emit.as_deref() {
+        None | Some("exe" | "executable") => false,
+        Some("obj" | "object") => true,
+        Some(other) => {
+            eprintln!("unknown --emit value: {other} (expected `exe` or `obj`)");
+            return 2;
+        }
+    };
+
     match outcome {
         BuildOutcome::NativeOk(p) => {
             println!("wrote {}", p.display());
             0
         }
-        BuildOutcome::NativeOkNoLinker(p) => {
-            println!(
-                "wrote object {} (no linker found; set $MTY_LINKER)",
-                p.display()
-            );
-            0
+        BuildOutcome::NativeOkNoLinker {
+            object_path,
+            discovery,
+        } => {
+            // v0.46 T2 — only treat object-only output as success when
+            // the caller explicitly asked for `--emit obj`. The default
+            // (and historic) behaviour is to build a native executable,
+            // so a missing linker must fail loudly: CI scripts and
+            // `set -e` shells used to greenlight builds that produced
+            // nothing runnable.
+            if emit_obj_only {
+                println!(
+                    "wrote object {} (no linker found; --emit obj keeps this as success)",
+                    object_path.display()
+                );
+                0
+            } else {
+                eprintln!(
+                    "wrote object {} but no linker is available to produce a native executable.",
+                    object_path.display()
+                );
+                eprintln!("{}", discovery.summary());
+                eprintln!("(pass `--emit obj` if you only need the object file)");
+                2
+            }
         }
         BuildOutcome::NativeLinkError { object_path, error } => {
             eprintln!(

--- a/crates/mty-cli/src/cmd/serve.rs
+++ b/crates/mty-cli/src/cmd/serve.rs
@@ -269,7 +269,7 @@ fn build_once(pkg_root: &Path) -> Result<PathBuf, BuildErr> {
         // Native outcomes can't be returned from a wasm build, but
         // we map them defensively rather than panic.
         BuildOutcome::NativeOk(_)
-        | BuildOutcome::NativeOkNoLinker(_)
+        | BuildOutcome::NativeOkNoLinker { .. }
         | BuildOutcome::NativeLinkError { .. } => {
             Err(BuildErr::Backend("unexpected native outcome".into()))
         }

--- a/crates/mty-cli/src/main.rs
+++ b/crates/mty-cli/src/main.rs
@@ -200,6 +200,13 @@ enum Cmd {
         /// `<pkg>-world` if none is declared.
         #[arg(long)]
         world: Option<String>,
+        /// v0.46 T2 — what to emit. `exe` (default) builds a native
+        /// executable and fails non-zero when no linker is available;
+        /// `obj` stops after the object file so CI scripts that only
+        /// need `.o` won't fail when no linker is installed.
+        /// Wasm targets ignore this flag.
+        #[arg(long)]
+        emit: Option<String>,
     },
     /// Print a human-readable explanation of a diagnostic code.
     Explain {
@@ -644,6 +651,7 @@ fn run_cli(cli: Cli) -> i32 {
             no_component,
             wasi,
             world,
+            emit,
         } => cmd::build::run(
             &path,
             debug,
@@ -653,6 +661,7 @@ fn run_cli(cli: Cli) -> i32 {
             no_component,
             wasi,
             world,
+            emit,
         ),
         Cmd::Inspect {
             sock,

--- a/crates/mty-cli/tests/cmd_build_exit.rs
+++ b/crates/mty-cli/tests/cmd_build_exit.rs
@@ -28,19 +28,28 @@ fn write_tempfile(name: &str, src: &str) -> PathBuf {
     p
 }
 
-/// Minimal PATH the child needs to load Windows system DLLs even when
-/// the test wants to "empty out" PATH for linker discovery. Without
-/// this, spawning the child hangs/loads forever waiting on DLLs that
-/// live under `system32` on Windows. On non-Windows we accept that an
-/// empty PATH genuinely is empty.
-#[cfg(windows)]
-fn minimal_path() -> String {
-    let sysroot = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".to_string());
-    format!("{sysroot}\\System32;{sysroot}")
-}
-#[cfg(not(windows))]
-fn minimal_path() -> String {
-    "/usr/bin:/bin".to_string()
+/// PATH the child needs to start up but that contains no linker.
+/// - Windows: `%SystemRoot%\System32` is the minimum the loader needs
+///   for KERNEL32.DLL etc. Without it, the spawned `mty.exe` hangs.
+///   No linker lives there, so PATH-fallback discovery still fails.
+/// - Linux/macOS: a fresh empty tempdir works as $PATH — no system
+///   directories are needed for the binary to start, and an empty
+///   tempdir keeps the PATH walk from discovering `cc`/`gcc` (which
+///   are universally present in `/usr/bin`).
+///
+/// Returns `(path_string, optional_tempdir_to_hold_lifetime)`.
+fn linkerless_path() -> (String, Option<tempfile::TempDir>) {
+    #[cfg(windows)]
+    {
+        let sysroot = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".to_string());
+        (format!("{sysroot}\\System32;{sysroot}"), None)
+    }
+    #[cfg(not(windows))]
+    {
+        let td = tempfile::tempdir().expect("tempdir for empty PATH");
+        let path = td.path().display().to_string();
+        (path, Some(td))
+    }
 }
 
 fn run_build(args: &[&str], env: &[(&str, &str)], env_remove: &[&str]) -> (i32, String, String) {
@@ -74,7 +83,7 @@ fn build_native_without_linker_exits_nonzero() {
     let out_dir = tempfile::tempdir().expect("tempdir");
     let src = write_tempfile("noexe", "fn main() {}\n");
     let out_arg = out_dir.path().display().to_string();
-    let path = minimal_path();
+    let (path, _path_keepalive) = linkerless_path();
     let (code, _stdout, stderr) = run_build(
         &[src.to_str().unwrap(), "--out-dir", &out_arg],
         &[
@@ -110,7 +119,7 @@ fn build_native_with_emit_obj_succeeds_without_linker() {
     let out_dir = tempfile::tempdir().expect("tempdir");
     let src = write_tempfile("emitobj", "fn main() {}\n");
     let out_arg = out_dir.path().display().to_string();
-    let path = minimal_path();
+    let (path, _path_keepalive) = linkerless_path();
     let (code, stdout, stderr) = run_build(
         &[
             src.to_str().unwrap(),

--- a/crates/mty-cli/tests/cmd_build_exit.rs
+++ b/crates/mty-cli/tests/cmd_build_exit.rs
@@ -1,0 +1,155 @@
+#![cfg(feature = "host-toolchain")]
+//! v0.46 T2 (L50) — `mty build` exit-code + MTY_LINKER discovery tests.
+//!
+//! Covers:
+//!   * When the requested target is native and no linker can be
+//!     discovered, `mty build` MUST exit non-zero (was previously 0,
+//!     silently shipping an object-only output that CI scripts could
+//!     not catch).
+//!   * `--emit obj` reinstates the historic "object-only is OK" path
+//!     so dedicated CI flows that don't need a runnable executable
+//!     don't break.
+//!   * The discovery diagnostic surfaces every candidate that was
+//!     tried (each env var + each PATH candidate name + outcome), so
+//!     a misconfigured `MTY_LINKER` is debuggable from the build log
+//!     alone.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn mty_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mty")
+}
+
+fn write_tempfile(name: &str, src: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("mty_build_t2_{}_{}.mty", std::process::id(), name));
+    std::fs::write(&p, src).expect("write temp .mty");
+    p
+}
+
+fn run_build(args: &[&str], env: &[(&str, &str)], env_remove: &[&str]) -> (i32, String, String) {
+    let mut cmd = Command::new(mty_bin());
+    cmd.arg("build");
+    for a in args {
+        cmd.arg(a);
+    }
+    for k in env_remove {
+        cmd.env_remove(k);
+    }
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("spawn mty build");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// v0.46 T2 — native build without a linker must exit non-zero.
+///
+/// We point `MTY_LINKER` at a value that resolves nowhere and stub
+/// `PATH` to an empty directory so the platform fallback can't rescue
+/// it either. The build MUST exit non-zero and the diagnostic MUST
+/// list every candidate it tried (the L50 ask).
+#[test]
+fn build_native_without_linker_exits_nonzero() {
+    let out_dir = tempfile::tempdir().expect("tempdir");
+    let empty_path = tempfile::tempdir().expect("tempdir for PATH");
+    let src = write_tempfile("noexe", "fn main() {}\n");
+    let out_arg = out_dir.path().display().to_string();
+    let (code, _stdout, stderr) = run_build(
+        &[src.to_str().unwrap(), "--out-dir", &out_arg],
+        &[
+            ("MTY_LINKER", "definitely-not-a-real-linker-xyz"),
+            ("PATH", &empty_path.path().display().to_string()),
+        ],
+        &["STARDUST_LINKER"],
+    );
+    assert_ne!(code, 0, "expected non-zero exit, stderr=\n{stderr}");
+    assert!(
+        stderr.contains("$MTY_LINKER"),
+        "diagnostic should mention $MTY_LINKER, stderr=\n{stderr}"
+    );
+    // The diagnostic must spell out every PATH candidate (per L50:
+    // "say what was actually tried"). Pick one platform-relevant
+    // name to assert.
+    let expected_cand = if cfg!(windows) { "clang.exe" } else { "clang" };
+    assert!(
+        stderr.contains(expected_cand),
+        "diagnostic should mention PATH candidates, stderr=\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--emit obj"),
+        "diagnostic should hint about --emit obj, stderr=\n{stderr}"
+    );
+}
+
+/// v0.46 T2 — `--emit obj` reinstates the historic "object-only
+/// success" exit code, so CI flows that genuinely don't need a
+/// runnable executable still pass.
+#[test]
+fn build_native_with_emit_obj_succeeds_without_linker() {
+    let out_dir = tempfile::tempdir().expect("tempdir");
+    let empty_path = tempfile::tempdir().expect("tempdir for PATH");
+    let src = write_tempfile("emitobj", "fn main() {}\n");
+    let out_arg = out_dir.path().display().to_string();
+    let (code, stdout, stderr) = run_build(
+        &[
+            src.to_str().unwrap(),
+            "--out-dir",
+            &out_arg,
+            "--emit",
+            "obj",
+        ],
+        &[
+            ("MTY_LINKER", "definitely-not-a-real-linker-xyz"),
+            ("PATH", &empty_path.path().display().to_string()),
+        ],
+        &["STARDUST_LINKER"],
+    );
+    assert_eq!(
+        code, 0,
+        "expected --emit obj to succeed without a linker, stderr=\n{stderr}\nstdout=\n{stdout}"
+    );
+    assert!(
+        stdout.contains("wrote object"),
+        "expected object-only success message, stdout=\n{stdout}"
+    );
+    // The .o must be on disk.
+    let obj = out_dir.path().join("mty_build_t2_obj.o");
+    // The actual basename comes from the source file stem; just
+    // verify some .o exists in the out dir.
+    let any_o = std::fs::read_dir(out_dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .any(|e| e.path().extension().and_then(|s| s.to_str()) == Some("o"));
+    assert!(any_o, "expected an .o file in {}, missing", obj.display());
+}
+
+/// v0.46 T2 — `--emit` rejects unknown values up front (a typo
+/// should not silently fall through to "build as native exe").
+#[test]
+fn build_rejects_unknown_emit_value() {
+    let out_dir = tempfile::tempdir().expect("tempdir");
+    let src = write_tempfile("emitbad", "fn main() {}\n");
+    let out_arg = out_dir.path().display().to_string();
+    let (code, _stdout, stderr) = run_build(
+        &[
+            src.to_str().unwrap(),
+            "--out-dir",
+            &out_arg,
+            "--emit",
+            "whatever",
+        ],
+        &[],
+        &[],
+    );
+    assert_eq!(code, 2, "expected exit 2 for bad --emit, stderr=\n{stderr}");
+    assert!(
+        stderr.contains("unknown --emit value"),
+        "expected emit-rejection diagnostic, stderr=\n{stderr}"
+    );
+}

--- a/crates/mty-cli/tests/cmd_build_exit.rs
+++ b/crates/mty-cli/tests/cmd_build_exit.rs
@@ -28,6 +28,21 @@ fn write_tempfile(name: &str, src: &str) -> PathBuf {
     p
 }
 
+/// Minimal PATH the child needs to load Windows system DLLs even when
+/// the test wants to "empty out" PATH for linker discovery. Without
+/// this, spawning the child hangs/loads forever waiting on DLLs that
+/// live under `system32` on Windows. On non-Windows we accept that an
+/// empty PATH genuinely is empty.
+#[cfg(windows)]
+fn minimal_path() -> String {
+    let sysroot = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".to_string());
+    format!("{sysroot}\\System32;{sysroot}")
+}
+#[cfg(not(windows))]
+fn minimal_path() -> String {
+    "/usr/bin:/bin".to_string()
+}
+
 fn run_build(args: &[&str], env: &[(&str, &str)], env_remove: &[&str]) -> (i32, String, String) {
     let mut cmd = Command::new(mty_bin());
     cmd.arg("build");
@@ -57,14 +72,14 @@ fn run_build(args: &[&str], env: &[(&str, &str)], env_remove: &[&str]) -> (i32, 
 #[test]
 fn build_native_without_linker_exits_nonzero() {
     let out_dir = tempfile::tempdir().expect("tempdir");
-    let empty_path = tempfile::tempdir().expect("tempdir for PATH");
     let src = write_tempfile("noexe", "fn main() {}\n");
     let out_arg = out_dir.path().display().to_string();
+    let path = minimal_path();
     let (code, _stdout, stderr) = run_build(
         &[src.to_str().unwrap(), "--out-dir", &out_arg],
         &[
             ("MTY_LINKER", "definitely-not-a-real-linker-xyz"),
-            ("PATH", &empty_path.path().display().to_string()),
+            ("PATH", &path),
         ],
         &["STARDUST_LINKER"],
     );
@@ -93,9 +108,9 @@ fn build_native_without_linker_exits_nonzero() {
 #[test]
 fn build_native_with_emit_obj_succeeds_without_linker() {
     let out_dir = tempfile::tempdir().expect("tempdir");
-    let empty_path = tempfile::tempdir().expect("tempdir for PATH");
     let src = write_tempfile("emitobj", "fn main() {}\n");
     let out_arg = out_dir.path().display().to_string();
+    let path = minimal_path();
     let (code, stdout, stderr) = run_build(
         &[
             src.to_str().unwrap(),
@@ -106,7 +121,7 @@ fn build_native_with_emit_obj_succeeds_without_linker() {
         ],
         &[
             ("MTY_LINKER", "definitely-not-a-real-linker-xyz"),
-            ("PATH", &empty_path.path().display().to_string()),
+            ("PATH", &path),
         ],
         &["STARDUST_LINKER"],
     );

--- a/crates/mty-codegen-cranelift/src/lib.rs
+++ b/crates/mty-codegen-cranelift/src/lib.rs
@@ -36,4 +36,7 @@ pub use artifact::NativeArtifact;
 pub use error::{CodegenError, CompileResult};
 pub use jit::{JitCompiled, JitMain};
 pub use mono::Monomorphizer;
-pub use object::{compile_object, compile_object_with_debug, ObjectArtifact};
+pub use object::{
+    compile_object, compile_object_with_debug, discover_linker, LinkerAttempt, LinkerDiscovery,
+    LinkerProbe, ObjectArtifact,
+};

--- a/crates/mty-codegen-cranelift/src/object.rs
+++ b/crates/mty-codegen-cranelift/src/object.rs
@@ -226,6 +226,72 @@ pub fn link_executable(
     link_executable_with_libs(obj, out_exe, mode, &[])
 }
 
+/// What a single linker-discovery probe found.
+///
+/// `LinkerProbe::Found(path)` means the candidate resolves to a real
+/// executable; `LinkerProbe::NotFound(reason)` means we couldn't use
+/// it. Both shapes are surfaced verbatim in [`LinkerDiscoveryError`]
+/// so the user can see exactly which candidates were tried and what
+/// each said.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkerProbe {
+    /// The candidate resolved to this absolute executable path.
+    Found(String),
+    /// The candidate did not resolve. The string explains why
+    /// (e.g. "unset", "not on PATH", "file does not exist").
+    NotFound(String),
+}
+
+/// A single env-var or PATH-candidate attempt during linker discovery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkerAttempt {
+    /// What we tried — for env vars, the var name (`"$MTY_LINKER"`);
+    /// for PATH candidates, the bare program name (`"clang"`,
+    /// `"cc"`, `"lld-link"`).
+    pub source: String,
+    /// The raw value we attempted (the env var's value, or the
+    /// PATH-candidate name itself if there was no env value).
+    pub value: Option<String>,
+    /// Outcome of the probe.
+    pub outcome: LinkerProbe,
+}
+
+/// Aggregated linker-discovery report: every candidate the discovery
+/// walk attempted and what each one said.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkerDiscovery {
+    pub attempts: Vec<LinkerAttempt>,
+}
+
+impl LinkerDiscovery {
+    /// Human-readable multi-line summary, suitable for an error log.
+    pub fn summary(&self) -> String {
+        let mut out = String::from("no linker found; tried:\n");
+        for a in &self.attempts {
+            out.push_str("  - ");
+            out.push_str(&a.source);
+            if let Some(v) = &a.value {
+                out.push_str(" = ");
+                out.push_str(v);
+            }
+            out.push_str(" -> ");
+            match &a.outcome {
+                LinkerProbe::Found(p) => {
+                    out.push_str("found ");
+                    out.push_str(p);
+                }
+                LinkerProbe::NotFound(reason) => out.push_str(reason),
+            }
+            out.push('\n');
+        }
+        out.push_str(
+            "  hint: set MTY_LINKER to the absolute path of clang/gcc/lld-link, \
+             or install one of the above on PATH",
+        );
+        out
+    }
+}
+
 /// Like [`link_executable`] but appends `extra_args` after the object
 /// file and libc. v0.36 Track T2 uses this to forward every
 /// `[[extern_lib]]` entry from `mighty.toml` into the linker invocation:
@@ -243,8 +309,15 @@ pub fn link_executable_with_libs(
     mode: BuildMode,
     extra_args: &[String],
 ) -> CompileResult<NativeArtifact> {
-    let linker = find_linker()
-        .ok_or_else(|| CodegenError::Linker("no linker found (set MTY_LINKER)".into()))?;
+    let linker = match discover_linker() {
+        Ok(p) => p,
+        Err(discovery) => return Err(CodegenError::Linker(discovery.summary())),
+    };
+    // v0.46 T2 — `Command::new` takes a single executable path,
+    // never a command line. Honour the discovered path verbatim
+    // (already de-quoted by `discover_linker`); arguments below
+    // are passed individually so spaces in the linker path never
+    // get re-split on whitespace.
     let mut cmd = Command::new(&linker);
     cmd.arg(&obj.object_path);
     cmd.arg("-o").arg(out_exe);
@@ -263,15 +336,54 @@ pub fn link_executable_with_libs(
     for a in extra_args {
         cmd.arg(a);
     }
-    let output = cmd
-        .output()
-        .map_err(|e| CodegenError::Linker(format!("invoke {linker}: {e}")))?;
+    let output = cmd.output().map_err(|e| {
+        CodegenError::Linker(format!(
+            "failed to invoke linker `{linker}`: {e}\n  \
+             hint: check that the path exists and is executable; \
+             on Windows ensure MTY_LINKER points at clang.exe / lld-link.exe (not a directory)"
+        ))
+    })?;
     if !output.status.success() {
-        return Err(CodegenError::Linker(format!(
-            "linker exited {:?}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        )));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let exit = output
+            .status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "signal".into());
+        let mut msg = format!("linker `{linker}` exited {exit}");
+        let trimmed_err = stderr.trim();
+        if !trimmed_err.is_empty() {
+            msg.push_str("\nstderr:\n");
+            msg.push_str(trimmed_err);
+        }
+        let trimmed_out = stdout.trim();
+        if !trimmed_out.is_empty() {
+            msg.push_str("\nstdout:\n");
+            msg.push_str(trimmed_out);
+        }
+        return Err(CodegenError::Linker(msg));
+    }
+    // v0.46 T2 — even when the linker reports success, double-check
+    // that the executable actually landed on disk and is non-empty.
+    // Some linkers (notably lld-link with certain flag mixes) can
+    // exit 0 after rejecting individual inputs without producing
+    // output; without this guard `mty build` would still claim
+    // success and CI scripts would silently ship nothing.
+    match std::fs::metadata(out_exe) {
+        Ok(meta) if meta.len() == 0 => {
+            return Err(CodegenError::Linker(format!(
+                "linker `{linker}` exited 0 but produced an empty {out}",
+                out = out_exe.display()
+            )));
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(CodegenError::Linker(format!(
+                "linker `{linker}` exited 0 but {out} was not produced",
+                out = out_exe.display()
+            )));
+        }
+        _ => {}
     }
     Ok(NativeArtifact {
         binary_path: out_exe.to_path_buf(),
@@ -291,27 +403,137 @@ pub fn link_executable_with_libs(
 /// We also reject MSYS/Git-Bash's `/usr/bin/link.exe` (the coreutils
 /// shim) when found at that exact path, since it speaks GNU
 /// arg-syntax, not MSVC's.
+///
+/// Returns the resolved name/path on success. For full attempt
+/// telemetry on failure (every env var and PATH candidate that was
+/// tried + what each said), use [`discover_linker`].
 pub fn find_linker() -> Option<String> {
-    // v0.36 T4: prefer MTY_LINKER, fall back to STARDUST_LINKER with
-    // a one-shot deprecation warning. This module is `no_std`-friendly
-    // enough that we can't depend on `mty-runtime`'s env helper, so
-    // we open-code the same precedence locally.
-    if let Ok(env) = std::env::var("MTY_LINKER") {
-        if !env.trim().is_empty() {
-            return Some(env);
+    discover_linker().ok()
+}
+
+/// v0.46 T2 — strip wrapping ASCII quotes around an env-var value so
+/// `MTY_LINKER="C:\Program Files\LLVM\bin\clang.exe"` works even on
+/// shells that leak the quotes into the var. Trims surrounding
+/// whitespace too.
+fn unquote(raw: &str) -> String {
+    let s = raw.trim();
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if first == last && (first == b'"' || first == b'\'') {
+            return s[1..s.len() - 1].to_string();
         }
     }
-    if let Ok(env) = std::env::var("STARDUST_LINKER") {
-        if !env.trim().is_empty() {
+    s.to_string()
+}
+
+/// v0.46 T2 — return `true` when `s` looks like a path (contains a
+/// directory separator) rather than a bare program name. Used to
+/// decide whether to PATH-walk a user-supplied env override.
+fn looks_like_path(s: &str) -> bool {
+    s.contains('/') || s.contains('\\')
+}
+
+/// v0.46 T2 — resolve `value` (an `MTY_LINKER` / `STARDUST_LINKER`
+/// payload) to an executable. Quoted paths are honoured. Bare names
+/// (`"clang"`, `"clang.exe"`) get a PATH walk. Paths are checked for
+/// existence so a typo surfaces as "file does not exist" instead of
+/// "failed to invoke".
+fn resolve_env_linker(value: &str) -> LinkerProbe {
+    let unquoted = unquote(value);
+    if unquoted.is_empty() {
+        return LinkerProbe::NotFound("empty after trimming quotes".into());
+    }
+    if looks_like_path(&unquoted) {
+        let p = std::path::Path::new(&unquoted);
+        if p.is_file() {
+            return LinkerProbe::Found(unquoted);
+        }
+        return LinkerProbe::NotFound(format!("file does not exist: {unquoted}"));
+    }
+    match which::which(&unquoted) {
+        Ok(path) => LinkerProbe::Found(path.to_string_lossy().into_owned()),
+        Err(()) => LinkerProbe::NotFound(format!("`{unquoted}` not found on PATH")),
+    }
+}
+
+/// v0.46 T2 — like [`find_linker`] but always returns the full
+/// discovery trace on failure so callers can surface an actionable
+/// diagnostic. Discovery order (unchanged):
+///
+/// 1. `MTY_LINKER` env override (quote-tolerant; bare names get a
+///    PATH walk).
+/// 2. `STARDUST_LINKER` legacy env override (same shape; one-shot
+///    deprecation warning).
+/// 3. Platform-conventional PATH candidates in priority order.
+pub fn discover_linker() -> Result<String, LinkerDiscovery> {
+    let mut attempts: Vec<LinkerAttempt> = Vec::new();
+
+    // 1. MTY_LINKER
+    match std::env::var("MTY_LINKER") {
+        Ok(raw) if !raw.trim().is_empty() => {
+            let probe = resolve_env_linker(&raw);
+            let resolved = matches!(probe, LinkerProbe::Found(_));
+            attempts.push(LinkerAttempt {
+                source: "$MTY_LINKER".into(),
+                value: Some(raw),
+                outcome: probe.clone(),
+            });
+            if let LinkerProbe::Found(p) = probe {
+                if !is_msys_coreutils_link(&p) {
+                    return Ok(p);
+                }
+                // The override resolved to MSYS' coreutils `link` —
+                // skip it but keep the attempt visible.
+                let _ = resolved;
+            }
+        }
+        Ok(_) => attempts.push(LinkerAttempt {
+            source: "$MTY_LINKER".into(),
+            value: None,
+            outcome: LinkerProbe::NotFound("set but empty/whitespace".into()),
+        }),
+        Err(_) => attempts.push(LinkerAttempt {
+            source: "$MTY_LINKER".into(),
+            value: None,
+            outcome: LinkerProbe::NotFound("unset".into()),
+        }),
+    }
+
+    // 2. STARDUST_LINKER legacy fallback
+    match std::env::var("STARDUST_LINKER") {
+        Ok(raw) if !raw.trim().is_empty() => {
             use std::sync::atomic::{AtomicBool, Ordering};
             static WARNED: AtomicBool = AtomicBool::new(false);
             if !WARNED.swap(true, Ordering::Relaxed) {
                 eprintln!("mighty: warning: STARDUST_LINKER is deprecated; use MTY_LINKER instead");
             }
-            return Some(env);
+            let probe = resolve_env_linker(&raw);
+            attempts.push(LinkerAttempt {
+                source: "$STARDUST_LINKER".into(),
+                value: Some(raw),
+                outcome: probe.clone(),
+            });
+            if let LinkerProbe::Found(p) = probe {
+                if !is_msys_coreutils_link(&p) {
+                    return Ok(p);
+                }
+            }
         }
+        Ok(_) => attempts.push(LinkerAttempt {
+            source: "$STARDUST_LINKER".into(),
+            value: None,
+            outcome: LinkerProbe::NotFound("set but empty/whitespace".into()),
+        }),
+        Err(_) => attempts.push(LinkerAttempt {
+            source: "$STARDUST_LINKER".into(),
+            value: None,
+            outcome: LinkerProbe::NotFound("unset".into()),
+        }),
     }
-    // v0.2 search order: clang first (works everywhere; drives lld),
+
+    // 3. PATH candidates. clang first (works everywhere; drives lld),
     // then platform-conventional Cs, then lld variants by themselves.
     let candidates: &[&str] = if cfg!(windows) {
         &[
@@ -327,18 +549,42 @@ pub fn find_linker() -> Option<String> {
         &["cc", "gcc", "clang", "ld.lld", "lld"]
     };
     for cand in candidates {
-        if let Ok(path) = which::which(cand) {
-            let s = path.to_string_lossy();
-            // Skip the coreutils `link.exe` shim that ships with
-            // MSYS/Git-Bash on Windows — it's a hardlink helper, not
-            // a linker.
-            if s.contains("/usr/bin/link") || s.contains("\\usr\\bin\\link") {
-                continue;
+        match which::which(cand) {
+            Ok(path) => {
+                let s = path.to_string_lossy().into_owned();
+                if is_msys_coreutils_link(&s) {
+                    attempts.push(LinkerAttempt {
+                        source: format!("PATH:{cand}"),
+                        value: Some(s),
+                        outcome: LinkerProbe::NotFound(
+                            "skipped (coreutils `link` shim, not a real linker)".into(),
+                        ),
+                    });
+                    continue;
+                }
+                attempts.push(LinkerAttempt {
+                    source: format!("PATH:{cand}"),
+                    value: None,
+                    outcome: LinkerProbe::Found(s),
+                });
+                return Ok((*cand).to_string());
             }
-            return Some(cand.to_string());
+            Err(()) => attempts.push(LinkerAttempt {
+                source: format!("PATH:{cand}"),
+                value: None,
+                outcome: LinkerProbe::NotFound("not on PATH".into()),
+            }),
         }
     }
-    None
+
+    Err(LinkerDiscovery { attempts })
+}
+
+/// MSYS / Git-Bash ship a coreutils `link.exe` (a hardlink helper)
+/// at `/usr/bin/link.exe`. It is not a real linker — skip it so we
+/// don't end up invoking it.
+fn is_msys_coreutils_link(s: &str) -> bool {
+    s.contains("/usr/bin/link") || s.contains("\\usr\\bin\\link")
 }
 
 // We don't depend on `which` in workspace deps — vendor a minimal
@@ -408,25 +654,33 @@ mod tests {
     #[test]
     fn find_linker_prefers_mty_over_stardust() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        // Set both; MTY_ should win and STARDUST_ shouldn't even be
-        // observed (no deprecation warning fires).
-        std::env::set_var("MTY_LINKER", "/path/to/new-linker");
-        std::env::set_var("STARDUST_LINKER", "/path/to/old-linker");
+        // v0.46 T2 — find_linker now validates that the env-supplied
+        // path exists, so we need a real file on disk. Use a tempdir
+        // sentinel.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let new_linker = dir.path().join("new-linker");
+        let old_linker = dir.path().join("old-linker");
+        std::fs::write(&new_linker, b"#fake").unwrap();
+        std::fs::write(&old_linker, b"#fake").unwrap();
+        std::env::set_var("MTY_LINKER", &new_linker);
+        std::env::set_var("STARDUST_LINKER", &old_linker);
         let got = find_linker();
         std::env::remove_var("MTY_LINKER");
         std::env::remove_var("STARDUST_LINKER");
-        assert_eq!(got.as_deref(), Some("/path/to/new-linker"));
+        assert_eq!(got.as_deref(), Some(new_linker.to_string_lossy().as_ref()));
     }
 
     #[test]
     fn find_linker_falls_back_to_stardust() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        // MTY_ unset, STARDUST_ set → fallback path is honoured.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let legacy = dir.path().join("legacy-linker");
+        std::fs::write(&legacy, b"#fake").unwrap();
         std::env::remove_var("MTY_LINKER");
-        std::env::set_var("STARDUST_LINKER", "/path/to/legacy-linker");
+        std::env::set_var("STARDUST_LINKER", &legacy);
         let got = find_linker();
         std::env::remove_var("STARDUST_LINKER");
-        assert_eq!(got.as_deref(), Some("/path/to/legacy-linker"));
+        assert_eq!(got.as_deref(), Some(legacy.to_string_lossy().as_ref()));
     }
 
     #[test]
@@ -450,15 +704,17 @@ mod tests {
         // remove_var, producing the `Some("clang.exe")` PATH-walk
         // fallthrough we saw on the integrator commit.
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        // Use a synthetic placeholder so the test doesn't depend on
-        // any tool actually being installed. The override path is
-        // returned verbatim — `find_linker` doesn't validate it.
+        // v0.46 T2 — use a real file on disk; the discovery layer now
+        // validates that the env-supplied path actually exists.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let synthetic = dir.path().join("synthetic-linker-for-test");
+        std::fs::write(&synthetic, b"#fake").unwrap();
         let prev_mty = std::env::var("MTY_LINKER").ok();
         let prev = std::env::var("STARDUST_LINKER").ok();
         // MTY_LINKER must be unset, else it takes precedence and
         // shadows the STARDUST_LINKER path we're trying to exercise.
         std::env::remove_var("MTY_LINKER");
-        std::env::set_var("STARDUST_LINKER", "synthetic-linker-for-test");
+        std::env::set_var("STARDUST_LINKER", &synthetic);
         let got = find_linker();
         // Restore env first so a panic below doesn't leak state.
         match prev {
@@ -468,7 +724,7 @@ mod tests {
         if let Some(v) = prev_mty {
             std::env::set_var("MTY_LINKER", v);
         }
-        assert_eq!(got.as_deref(), Some("synthetic-linker-for-test"));
+        assert_eq!(got.as_deref(), Some(synthetic.to_string_lossy().as_ref()));
     }
 
     /// v0.36 Track T2 — when `STARDUST_LINKER` is whitespace, the
@@ -492,6 +748,153 @@ mod tests {
         // We can't assert the PATH-walked result (CI varies), but it
         // must NOT be the whitespace value we passed.
         assert_ne!(got.as_deref(), Some("   "));
+    }
+
+    /// v0.46 T2 — `unquote` strips wrapping ASCII quotes so that
+    /// `MTY_LINKER='"C:\Program Files\LLVM\bin\clang.exe"'` works on
+    /// shells that leak the quotes into the env var.
+    #[test]
+    fn unquote_strips_double_and_single_wrap() {
+        assert_eq!(
+            unquote("\"C:\\Program Files\\LLVM\\bin\\clang.exe\""),
+            "C:\\Program Files\\LLVM\\bin\\clang.exe"
+        );
+        assert_eq!(unquote("'/usr/local/bin/clang'"), "/usr/local/bin/clang");
+        // Unwrapped path passes through.
+        assert_eq!(unquote("/usr/local/bin/clang"), "/usr/local/bin/clang");
+        // Mixed quotes — only an outer matched pair counts.
+        assert_eq!(unquote("\"mixed'"), "\"mixed'");
+        // Whitespace trimming.
+        assert_eq!(unquote("  /bin/cc  "), "/bin/cc");
+        // Quoted whitespace path.
+        assert_eq!(unquote("\"  /bin/cc  \""), "  /bin/cc  ");
+    }
+
+    /// v0.46 T2 — `looks_like_path` distinguishes a bare program
+    /// name (which we PATH-walk) from a real path (which we just
+    /// stat).
+    #[test]
+    fn looks_like_path_distinguishes_path_from_name() {
+        assert!(looks_like_path("/usr/bin/clang"));
+        assert!(looks_like_path("C:\\LLVM\\clang.exe"));
+        assert!(looks_like_path("./clang"));
+        assert!(!looks_like_path("clang"));
+        assert!(!looks_like_path("clang.exe"));
+        assert!(!looks_like_path("lld-link"));
+    }
+
+    /// v0.46 T2 — when `MTY_LINKER` is a bare program name we must
+    /// PATH-walk it instead of treating it as a relative file. With
+    /// a synthetic name nothing on PATH matches; the probe reports
+    /// `not found on PATH` (not "file does not exist").
+    #[test]
+    fn resolve_env_linker_path_walks_bare_names() {
+        let probe = resolve_env_linker("definitely-not-a-real-tool-xyz");
+        match probe {
+            LinkerProbe::NotFound(reason) => {
+                assert!(
+                    reason.contains("not found on PATH"),
+                    "expected PATH walk failure, got {reason}"
+                );
+            }
+            LinkerProbe::Found(p) => panic!("unexpected hit: {p}"),
+        }
+    }
+
+    /// v0.46 T2 — a quoted path that points at an existing file
+    /// resolves cleanly even when the path contains spaces.
+    #[test]
+    fn resolve_env_linker_honours_quoted_path_with_spaces() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Force a sub-dir with a space in the name; this is the
+        // failure mode reported by L50 (`C:\Program Files\...`).
+        let nested = dir.path().join("Program Files");
+        std::fs::create_dir(&nested).unwrap();
+        let exe = nested.join("clang.exe");
+        std::fs::write(&exe, b"#fake").unwrap();
+        let quoted = format!("\"{}\"", exe.display());
+        let probe = resolve_env_linker(&quoted);
+        match probe {
+            LinkerProbe::Found(p) => assert_eq!(
+                std::path::Path::new(&p),
+                exe.as_path(),
+                "unexpected resolved path"
+            ),
+            LinkerProbe::NotFound(reason) => {
+                panic!("expected quoted path with spaces to resolve, got NotFound({reason})")
+            }
+        }
+    }
+
+    /// v0.46 T2 — a path that doesn't exist surfaces an actionable
+    /// "file does not exist" error rather than getting passed
+    /// through to `Command::new` (which would fail later with a less
+    /// helpful "the system cannot find the file specified").
+    #[test]
+    fn resolve_env_linker_rejects_missing_path() {
+        let probe = resolve_env_linker("/definitely/not/a/real/path/clang");
+        match probe {
+            LinkerProbe::NotFound(reason) => {
+                assert!(
+                    reason.contains("file does not exist"),
+                    "unexpected reason: {reason}"
+                );
+            }
+            LinkerProbe::Found(p) => panic!("expected NotFound, got Found({p})"),
+        }
+    }
+
+    /// v0.46 T2 — `LinkerDiscovery::summary` mentions every attempted
+    /// candidate name plus the explicit hint about `MTY_LINKER`. This
+    /// is the diagnostic surface CI users see when discovery fails.
+    #[test]
+    fn discovery_summary_lists_every_attempt() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_mty = std::env::var("MTY_LINKER").ok();
+        let prev_sd = std::env::var("STARDUST_LINKER").ok();
+        let prev_path = std::env::var("PATH").ok();
+        std::env::remove_var("MTY_LINKER");
+        std::env::remove_var("STARDUST_LINKER");
+        // Make PATH point somewhere empty so every candidate misses.
+        let empty = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("PATH", empty.path());
+        let result = discover_linker();
+        // Restore env before any assertion.
+        if let Some(v) = prev_path {
+            std::env::set_var("PATH", v);
+        } else {
+            std::env::remove_var("PATH");
+        }
+        if let Some(v) = prev_mty {
+            std::env::set_var("MTY_LINKER", v);
+        }
+        if let Some(v) = prev_sd {
+            std::env::set_var("STARDUST_LINKER", v);
+        }
+        let discovery = result.expect_err("PATH is empty, discovery must fail");
+        let summary = discovery.summary();
+        assert!(summary.contains("$MTY_LINKER"), "missing $MTY_LINKER probe");
+        assert!(
+            summary.contains("$STARDUST_LINKER"),
+            "missing $STARDUST_LINKER probe"
+        );
+        // Every platform-conventional candidate must appear by name.
+        if cfg!(windows) {
+            for cand in &["clang.exe", "gcc.exe", "cc.exe", "lld-link.exe"] {
+                assert!(summary.contains(cand), "missing PATH candidate {cand}");
+            }
+        } else {
+            for cand in &["cc", "gcc", "clang", "ld.lld", "lld"] {
+                assert!(
+                    summary.contains(&format!("PATH:{cand}")),
+                    "missing PATH candidate {cand}"
+                );
+            }
+        }
+        assert!(
+            summary.contains("MTY_LINKER"),
+            "missing actionable hint about MTY_LINKER"
+        );
     }
 
     /// v0.36 Track T2 — `link_executable_with_libs` appends every

--- a/crates/mty-driver/src/build.rs
+++ b/crates/mty-driver/src/build.rs
@@ -12,7 +12,10 @@ use mty_codegen_cranelift::{
     artifact::BuildMode,
     error::CodegenError,
     jit::{build_jit, symbols_from},
-    object::{compile_object, compile_object_with_debug, find_linker, link_executable_with_libs},
+    object::{
+        compile_object, compile_object_with_debug, discover_linker, link_executable_with_libs,
+        LinkerDiscovery,
+    },
     Monomorphizer,
 };
 use mty_codegen_wasm::{
@@ -199,8 +202,20 @@ pub fn build_linker_args(libs: &[ExternLib], manifest_dir: Option<&Path>) -> Vec
 #[derive(Debug)]
 pub enum BuildOutcome {
     NativeOk(PathBuf),
-    NativeOkNoLinker(PathBuf), // emitted .o but no linker available
-    NativeLinkError { object_path: PathBuf, error: String },
+    /// v0.46 T2 — discovery failed for every candidate. The `.o` was
+    /// still emitted (`object_path`); `discovery` carries the per-
+    /// candidate trace for actionable diagnostics. CLI callers
+    /// building for the native executable target MUST treat this as
+    /// a failure (`mty build` returns non-zero) — only object-only
+    /// emit modes (`--emit obj`) may keep it as success.
+    NativeOkNoLinker {
+        object_path: PathBuf,
+        discovery: LinkerDiscovery,
+    },
+    NativeLinkError {
+        object_path: PathBuf,
+        error: String,
+    },
     WasmOk(PathBuf),
     FrontendError, // diagnostics already rendered
     BackendError(String),
@@ -232,8 +247,14 @@ pub fn build_native(src: String, source_id: String, opts: &BuildOptions) -> Buil
         Ok(a) => a,
         Err(e) => return BuildOutcome::BackendError(format!("codegen: {e}")),
     };
-    let Some(linker_path) = find_linker() else {
-        return BuildOutcome::NativeOkNoLinker(obj.object_path);
+    let linker_path = match discover_linker() {
+        Ok(p) => p,
+        Err(discovery) => {
+            return BuildOutcome::NativeOkNoLinker {
+                object_path: obj.object_path,
+                discovery,
+            };
+        }
     };
     let exe_path = exe_path_for(&opts.out_dir, &opts.binary_name);
     // v0.36 T2: translate the manifest's [[extern_lib]] set into raw
@@ -499,7 +520,7 @@ fn main() {{
         // Either we got a native binary or just the .o (no linker).
         match outcome {
             BuildOutcome::NativeOk(p) => assert!(p.exists()),
-            BuildOutcome::NativeOkNoLinker(p) => assert!(p.exists()),
+            BuildOutcome::NativeOkNoLinker { object_path, .. } => assert!(object_path.exists()),
             BuildOutcome::NativeLinkError { object_path, .. } => {
                 assert!(object_path.exists(), "expected emitted object")
             }

--- a/crates/mty-driver/tests/extern_c_matrix.rs
+++ b/crates/mty-driver/tests/extern_c_matrix.rs
@@ -329,7 +329,7 @@ fn run_row(row_dir: &Path, marker: Option<&str>) {
     let outcome = build_native(app_src, row_dir.display().to_string(), &opts);
     let bin = match outcome {
         BuildOutcome::NativeOk(p) => p,
-        BuildOutcome::NativeOkNoLinker(p) => {
+        BuildOutcome::NativeOkNoLinker { object_path: p, .. } => {
             // No linker was discovered during the driver build. The
             // matrix needs a runnable binary, so try the link step
             // directly and surface its exact error instead of silently

--- a/crates/mty-driver/tests/fs_native_v045_t1.rs
+++ b/crates/mty-driver/tests/fs_native_v045_t1.rs
@@ -408,7 +408,7 @@ fn build_and_run(name: &str, src: String) -> Option<i32> {
     let outcome = build_native(src, format!("{name}.mty"), &opts);
     let exe = match outcome {
         BuildOutcome::NativeOk(p) => p,
-        BuildOutcome::NativeOkNoLinker(_) => {
+        BuildOutcome::NativeOkNoLinker { .. } => {
             eprintln!("[fs_native_v045_t1] no linker after probe; skipping");
             return None;
         }

--- a/crates/mty-driver/tests/manifest_build_link.rs
+++ b/crates/mty-driver/tests/manifest_build_link.rs
@@ -253,8 +253,15 @@ fn build_native_with_build_block_threads_native_libs() {
     // success, no-linker, and a real linker rejection are all
     // acceptable as long as codegen produced the object.
     match outcome {
-        BuildOutcome::NativeOk(p) | BuildOutcome::NativeOkNoLinker(p) => {
+        BuildOutcome::NativeOk(p) => {
             assert!(p.exists(), "expected artifact at {}", p.display());
+        }
+        BuildOutcome::NativeOkNoLinker { object_path, .. } => {
+            assert!(
+                object_path.exists(),
+                "expected artifact at {}",
+                object_path.display()
+            );
         }
         BuildOutcome::NativeLinkError { object_path, .. } => {
             assert!(
@@ -292,7 +299,7 @@ fn build_native_with_default_build_block_is_no_op() {
     };
     let outcome = build_native("fn main() {}\n".into(), "noop.mty".into(), &opts);
     match outcome {
-        BuildOutcome::NativeOk(_) | BuildOutcome::NativeOkNoLinker(_) => {}
+        BuildOutcome::NativeOk(_) | BuildOutcome::NativeOkNoLinker { .. } => {}
         BuildOutcome::NativeLinkError { object_path, .. } => {
             assert!(object_path.exists(), "expected emitted object")
         }

--- a/crates/mty-driver/tests/native_dynamic_log.rs
+++ b/crates/mty-driver/tests/native_dynamic_log.rs
@@ -45,7 +45,7 @@ fn native_build_with_dynamic_log_succeeds() {
         &opts(&dir, "dyn_log"),
     );
     match outcome {
-        BuildOutcome::NativeOk(p) | BuildOutcome::NativeOkNoLinker(p) => {
+        BuildOutcome::NativeOk(p) | BuildOutcome::NativeOkNoLinker { object_path: p, .. } => {
             assert!(p.exists(), "expected built artifact at {}", p.display());
             let bytes = std::fs::read(&p).expect("read artifact");
             assert!(!bytes.is_empty(), "artifact is empty");
@@ -87,7 +87,7 @@ fn native_build_with_u8_widening_succeeds() {
         &opts(&dir, "widen_main"),
     );
     match outcome {
-        BuildOutcome::NativeOk(p) | BuildOutcome::NativeOkNoLinker(p) => {
+        BuildOutcome::NativeOk(p) | BuildOutcome::NativeOkNoLinker { object_path: p, .. } => {
             assert!(p.exists());
         }
         BuildOutcome::NativeLinkError { object_path, .. } => {
@@ -117,7 +117,7 @@ fn native_build_with_hex_suffix_literals() {
         &opts(&dir, "hex_literals"),
     );
     match outcome {
-        BuildOutcome::NativeOk(p) | BuildOutcome::NativeOkNoLinker(p) => {
+        BuildOutcome::NativeOk(p) | BuildOutcome::NativeOkNoLinker { object_path: p, .. } => {
             assert!(p.exists());
         }
         BuildOutcome::NativeLinkError { object_path, .. } => {

--- a/crates/mty-driver/tests/typed_log_v042_t4.rs
+++ b/crates/mty-driver/tests/typed_log_v042_t4.rs
@@ -38,7 +38,7 @@ fn must_native_object(name: &str, src: &str) {
     let dir = tempfile::tempdir().expect("tempdir");
     let outcome = build_native(src.to_string(), format!("{name}.mty"), &opts(&dir, name));
     match outcome {
-        BuildOutcome::NativeOk(p) | BuildOutcome::NativeOkNoLinker(p) => {
+        BuildOutcome::NativeOk(p) | BuildOutcome::NativeOkNoLinker { object_path: p, .. } => {
             assert!(p.exists(), "expected built artifact at {}", p.display());
             let bytes = std::fs::read(&p).expect("read artifact");
             assert!(!bytes.is_empty(), "artifact is empty");

--- a/crates/mty-driver/tests/vec_liveness_native_v042.rs
+++ b/crates/mty-driver/tests/vec_liveness_native_v042.rs
@@ -311,7 +311,7 @@ fn build_and_run(name: &str, src: &str) -> Option<(i32, String)> {
     let outcome = build_native(src.to_string(), format!("{name}.mty"), &opts);
     let exe_path = match outcome {
         BuildOutcome::NativeOk(p) => p,
-        BuildOutcome::NativeOkNoLinker(p) => {
+        BuildOutcome::NativeOkNoLinker { object_path: p, .. } => {
             eprintln!(
                 "[vec_liveness_native_v042] {name}: only emitted .o ({}); skipping execute step",
                 p.display()


### PR DESCRIPTION
## Summary

L50 fixes (P1 from mighty-ide lessons):

- `mty build` returns non-zero when no executable produced (was exit 0 with "wrote object ... (no linker found)" leaving CI scripts unable to detect failure)
- `MTY_LINKER` honors Windows paths with spaces (e.g. `C:\Program Files\LLVM\bin\clang.exe`)
- `MTY_LINKER` accepts bare names resolved via PATH (e.g. `MTY_LINKER=clang`)
- Linker-discovery failure logs each candidate tried + reason
- Linker run failure surfaces linker stderr (was swallowed)

Object-only output (`--emit obj`) stays exit 0.

## Test plan
- [x] 5 new tests in `crates/mty-cli/tests/cmd_build_exit.rs`
- [x] Pre-push hook (fmt + clippy + mty fmt --check) clean
- [x] 13 files updated, +696/-66