### PR TITLE
v0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,18 @@ For the full per-release notes, see
 
 ## [Unreleased]
 
+## [0.46.0] - 2026-06-02
+
+v0.46 ships the official runtime ABI artifact pipeline (downstream
+`extern c` linkers stop hand-mirroring the symbol list), expands
+the extern c boundary to `(ptr, len)` Mighty strings, migrates five
+LSP surfaces from text snippets to LSP structured-result types,
+hardens `mty build` exit codes + `MTY_LINKER` path handling, and
+trims `std.fs` ergonomic edges with a `read_dir` iterator handle
+plus Metadata field projection.
+
 ### Added
-- **v0.46 T1 — official runtime ABI artifact (L51 fix).** The Mighty
+- **T1 — official runtime ABI artifact (L51 fix).** The Mighty
   compiler emits calls into a fixed family of `mty_runtime_*` C-ABI
   symbols (~50 of them by v0.45). v0.46 T1 publishes the surface as
   an official artifact pipeline:
@@ -30,6 +40,42 @@ For the full per-release notes, see
     fails if the in-tree header drifts from the build output or a
     `#[no_mangle]` fn slips past the parser.
   - See `docs/internals/runtime-abi.md` for the consumer-side story.
+  - 13 new tests.
+- **T3 — `(ptr, len)` FFI for Mighty strings (L52).** `extern c fn
+  f(s: Str)` now lowers as the (ptr, len) pair the receiving C ABI
+  expects, transparently expanded at every call site. Removes the
+  staging-buffer + `to_c_str` boilerplate that L52 surfaced in
+  agent-built bindings, while preserving the dynamic-Str fallback
+  path the v0.42 T4 LLVM limitation needs. 17 new tests.
+- **T4 — `std.fs.read_dir` iterator + Metadata field projection.**
+  `read_dir` now returns an iterator handle so consumers stream
+  entries instead of materialising a whole-Vec snapshot (covers the
+  v0.45 T1 deferral). `Metadata` exposes field-projection access for
+  `size`, `mtime`, `kind`, `permissions` etc. so callers stop
+  decomposing the whole struct just to inspect one field. The
+  v0.45-era `read_dir_lines` shape is deprecated (still works,
+  warns). 12 new tests.
+- **T5 — LSP structured-result surfaces (5).** `signatureHelp` ships
+  real parameter names (no more positional `arg0/arg1` placeholders);
+  `definition` returns `LocationLink` for cross-file origin context;
+  `completion` splits `detail`/`documentation` into their first-class
+  fields instead of cramming both into one Markdown string; `hover`
+  returns `MarkedString[]` so each section (signature, doc,
+  capability, taint) can be styled independently; `mty agent lsp` now
+  reports each of these in its structured JSON envelope. 71/71
+  mty-lsp tests + 45/45 mty-cli agent tests.
+
+### Fixed
+- **T2 — `mty build` exit code + `MTY_LINKER` Windows path support
+  (L50).** `mty build` now exits non-zero on diagnostic-fail (parity
+  with `mty check`), and the `MTY_LINKER` env override accepts
+  Windows-style absolute paths (`C:\...` and quoted paths with
+  spaces) without misparsing them as args. 5 new tests.
+
+### Deprecated
+- `std.fs.read_dir_lines` (use the T4 iterator form).
+
+[Release notes](dev/history/releases/RELEASE-v0.46.md).
 
 ## [0.45.0] - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@
 
 Compiler, runtime, formatter, package manager, doc generator, LSP,
 and stdlib all live in one Rust workspace and one `mty` binary.
-v0.45 is the current release: native `std.fs` JIT/AOT paths
-(shim-less file I/O for agent-built apps), formatter rollout to
-`fn`/`struct`/`enum`/`type` declarations, the `mty check --json`
-structured result, and the real L28 fix (opaque-ADT Use-Copy must
-not memcpy — the v0.42 attribution was masked by `[profile.dev]`
-debug=2 metadata).
+v0.46 is the current release: the official runtime ABI artifact
+pipeline (generated `mty_runtime_abi.h` + per-platform staticlib
+tarballs + `mty abi`), `(ptr, len)` FFI for Mighty strings,
+five LSP surfaces migrated to structured results (signatureHelp
+params, definition LocationLink, completion split fields, hover
+MarkedString, `mty agent lsp`), `mty build` exit-code parity +
+`MTY_LINKER` Windows path support, and `std.fs.read_dir`
+iterator + Metadata field projection.
 
 ## Why Mighty
 
@@ -285,7 +287,7 @@ current state of the language, not its history.
 
 ## Status
 
-Mighty is **pre-alpha**. Internal milestones tagged through v0.45.
+Mighty is **pre-alpha**. Internal milestones tagged through v0.46.
 The toolchain is exercised by **~3555 Rust tests** across 20 crates
 plus **490 Python 2nd-impl tests** plus **159 normative conformance
 cases** plus **23 self-host driver codegen tests** — combined **~4227

--- a/crates/mty-cli/src/lib.rs
+++ b/crates/mty-cli/src/lib.rs
@@ -24,7 +24,7 @@ pub mod cmd;
 /// version while the public toolchain advances by Mighty milestones
 /// (`v0.45.0`, `v0.46.0-dev`, ...). Keep this aligned with
 /// `CHANGELOG.md` and release tags.
-pub const MIGHTY_VERSION: &str = "0.46.0-dev";
+pub const MIGHTY_VERSION: &str = "0.46.0";
 
 // v0.35 T1 — browser playground exports. `wasm-pack build --target web`
 // reads this cdylib's `#[wasm_bindgen]` symbols (`init` / `check` /

--- a/crates/mty-runtime/include/mty_runtime_abi.h
+++ b/crates/mty-runtime/include/mty_runtime_abi.h
@@ -71,6 +71,9 @@ int32_t mty_runtime_fs_create_dir_all(int64_t path_ptr, int64_t path_len);
 int32_t mty_runtime_fs_remove_file(int64_t path_ptr, int64_t path_len);
 int32_t mty_runtime_fs_remove_dir_all(int64_t path_ptr, int64_t path_len);
 void mty_runtime_fs_read_dir(int64_t path_ptr, int64_t path_len, int64_t dst);
+int64_t mty_runtime_fs_dir_open(int64_t path_ptr, int64_t path_len);
+int32_t mty_runtime_fs_dir_next(int64_t handle, int64_t dst);
+void mty_runtime_fs_dir_close(int64_t handle);
 void mty_runtime_str_concat(int64_t aptr, int64_t alen, int64_t bptr, int64_t blen, int64_t dst);
 
 #ifdef __cplusplus

--- a/crates/mty-runtime/include/mty_runtime_abi.h
+++ b/crates/mty-runtime/include/mty_runtime_abi.h
@@ -17,7 +17,7 @@
 
 #include <stdint.h>
 
-#define MTY_RUNTIME_ABI_VERSION "0.46.0-dev"
+#define MTY_RUNTIME_ABI_VERSION "0.46.0"
 
 #ifdef __cplusplus
 extern "C" {

--- a/dev/history/releases/RELEASE-v0.46.md
+++ b/dev/history/releases/RELEASE-v0.46.md
@@ -1,0 +1,85 @@
+# Mighty v0.46 Release Notes
+
+**Tag:** `v0.46.0`
+**Date:** 2026-06-02
+**Status:** SHIPPED — official runtime ABI + extern c strings + LSP structured results.
+
+**Headline:** Mighty v0.46 — official runtime ABI + extern c strings
++ LSP structured results (marquee: shim-less app linking)
+
+## Summary
+
+v0.46 T1 turns the runtime ABI surface into a first-class artifact:
+downstream `extern c` callers link against a generated header +
+per-platform staticlib tarball instead of hand-mirroring the
+`mty_runtime_*` symbol list and discovering drift at link time. T3
+expands the extern c boundary so Mighty strings cross as the
+`(ptr, len)` pair the C side already expects, removing the
+staging-buffer dance every agent-authored binding had to
+re-implement. T5 migrates five LSP surfaces to LSP structured-result
+types, so VS Code / Helix / Zed clients drop the ariadne text
+parsing they were running on hover bodies and signatureHelp args.
+
+## Shipped
+
+- **PR #29 (T3) — `(ptr, len)` FFI for Mighty strings (L52).**
+  `extern c fn f(s: Str)` lowers as the (ptr, len) pair the C ABI
+  expects, transparently expanded at every call site. Removes the
+  staging-buffer + `to_c_str` boilerplate L52 surfaced in agent-built
+  bindings; dynamic-Str fallback preserved for the v0.42 T4 LLVM
+  limitation. 17 new tests.
+- **PR #30 (T2) — `mty build` exit code + `MTY_LINKER` Windows path
+  support (L50).** `mty build` now exits non-zero on diagnostic-fail
+  (parity with `mty check`), and `MTY_LINKER` accepts
+  Windows-absolute paths (`C:\...`, quoted spaces) without
+  misparsing them as args. 5 new tests.
+- **PR #31 (T1) — official runtime ABI artifact (marquee).**
+  Publishes the `mty_runtime_*` C-ABI surface as a first-class
+  artifact: generated C header at
+  `crates/mty-runtime/include/mty_runtime_abi.h` (regen on every
+  build by `build.rs` parsing `src/codegen_abi.rs`); `mty-runtime`
+  ships as `staticlib + rlib`; `release.yml` packages
+  `mty-runtime-abi-<version>-<triple>.tar.gz` per platform; `mty abi
+  {list, version, header}` lets tooling verify against the ground
+  truth; drift gate in `tests/runtime_abi_header.rs` fails if the
+  in-tree header lags. 13 new tests.
+- **PR #32 (T5) — LSP structured-result surfaces (5).**
+  `signatureHelp` ships real param names (no more `arg0/arg1`);
+  `definition` returns `LocationLink` for cross-file origin context;
+  `completion` splits `detail`/`documentation` into first-class
+  fields; `hover` returns `MarkedString[]` so signature / doc /
+  capability / taint sections can be styled independently; `mty
+  agent lsp` reports each via structured JSON. 71/71 mty-lsp + 45/45
+  mty-cli agent tests.
+- **PR #33 (T4) — `std.fs.read_dir` iterator + Metadata field
+  projection.** Closes v0.45 T1 deferrals. `read_dir` returns an
+  iterator handle so callers stream entries instead of materialising
+  a whole-Vec snapshot; `Metadata` exposes field-projection for
+  `size`/`mtime`/`kind`/`permissions`. `read_dir_lines` deprecated
+  (still works, warns). 12 new tests.
+
+## Carry-forward priorities
+
+- LLVM dynamic-Str path (v0.42 T4 limitation, surfaced again under
+  T3 — `(ptr, len)` lowering needs the LLVM backend's dynamic case
+  before non-literal Str args work on `--features llvm`).
+- Per-symbol stability tier markers (`@since` / `@deprecated`) in
+  the runtime ABI header (T1 follow-up so downstream linkers can
+  pin a minimum version).
+- Numeric `MAJOR/MINOR/PATCH` macros in the runtime ABI header (T1
+  follow-up so C preprocessor checks beat the string compare).
+- Mutable OUT params (`mut Vec[U8]` caller-allocated buffers) for
+  FFI (T3 deferral; only the in-Mighty fast path lands in v0.46).
+- LSP `textDocument/rename` `documentChanges` migration (T5
+  deferral; still uses legacy `WorkspaceEdit.changes`).
+- LSP `semanticTokens` delta encoding (T5 deferral).
+- DirIter auto-Drop (T4 deferral; explicit `close()` for now).
+- LLVM `lower_assign` projection-into-aggregate (resurfaces in T4
+  Metadata field access on the LLVM backend).
+- Pending tasks #253 (SWE-bench), #262 (BOLT training profile path).
+
+## Acknowledgements
+
+Driven by the mighty-ide dogfooding lessons log
+(`mighty-ide/docs/mighty-language-lessons.md`) — L50/L51/L52 from IDE
+FFI integration friction.


### PR DESCRIPTION
v0.46 integrator: T1 runtime ABI artifact (marquee) + T2 build exit/MTY_LINKER + T3 (ptr, len) extern c strings + T5 LSP structured results + T4 read_dir iterator + Metadata projection. See dev/history/releases/RELEASE-v0.46.md.