### PR TITLE
v0.48: Vec-of-aggregate codegen — inference + sizing + Vec[String]-push SIGSEGV fix (#297 partial)

### DIFF
--- a/crates/mty-cli/tests/conformance_examples.rs
+++ b/crates/mty-cli/tests/conformance_examples.rs
@@ -73,12 +73,35 @@ enum KnownReason {
     /// stubs or make codegen refuse the call cleanly.
     MainTakesCapabilities,
     /// `Vec[T]` where `T` is an aggregate (`String`, `struct`, …).
-    /// The SIR lowerer types the temp holding `Vec.new()` as
-    /// `IrTy::Error` so the element width is the i64 fallback (8)
-    /// instead of the real `T` size; the memcpy stride mismatch
-    /// corrupts memory. Documented in v0.41 T3 RELEASE notes as a
-    /// v0.42 typeck-side follow-up (the codegen side is correct;
-    /// the SIR loses the type info before lowering sees it).
+    ///
+    /// This is a LAYERED defect. v0.48 (#297) fixed three of the four
+    /// layers (all regression-free, verified by CLIF + this sweep):
+    ///   1. Push-only element inference — a Vec whose `T` was pinned
+    ///      only by `.push(x)` (no annotation / annotated return) left
+    ///      `T` an unresolved var. Fixed in mty-types: `Vec.new()` /
+    ///      `with_capacity()` now synth `Vec[?E]` and `push(x)` unifies
+    ///      `x` with `E`.
+    ///   2. `Vec.new()` result-temp typing — the temp holding the
+    ///      constructor was `IrTy::Error`, so `emit_vec_new` read the
+    ///      element size off an Error `current_dest_ty` and stored the
+    ///      8-byte fallback in the header. Fixed in mty-ir
+    ///      (`vec_call_result_ty`): the temp now carries the real
+    ///      `Vec[T]`, so the header records the true element size (16
+    ///      for `String`), and the element store memcpys the right width.
+    ///   3. (Consequence of 1+2) the grow-buffer allocation + element
+    ///      store now use a consistent, correct element size.
+    ///
+    /// REMAINING (layer 4, still KNOWN_FAILING): pushing an *aggregate*
+    /// element (e.g. a `String` from `String.from_str(...)`) still
+    /// segfaults. `emit_vec_push` memcpys `elem_size` bytes treating the
+    /// pushed operand as the source aggregate's ADDRESS, but
+    /// `eval_operand` on the bare call-result temp returns the call's
+    /// returned VALUE (the i64 `from_str` produced), not a stable
+    /// 16-byte `{ptr,len}` slot address. The fix needs the String-value
+    /// ABI threaded so an aggregate push sources from a real slot
+    /// address (and transfers ownership so drop doesn't double-free).
+    /// Minimal repro: `let mut v: Vec[String] = Vec.new();
+    /// v.push(String.from_str("a"))` — interp ok, JIT SIGSEGV.
     VecOfAggregate,
     /// v0.45 T1 native `std.fs` now actually touches disk under the
     /// JIT path. Examples that write to absolute hard-coded paths

--- a/crates/mty-cli/tests/conformance_examples.rs
+++ b/crates/mty-cli/tests/conformance_examples.rs
@@ -91,17 +91,24 @@ enum KnownReason {
     ///   3. (Consequence of 1+2) the grow-buffer allocation + element
     ///      store now use a consistent, correct element size.
     ///
-    /// REMAINING (layer 4, still KNOWN_FAILING): pushing an *aggregate*
-    /// element (e.g. a `String` from `String.from_str(...)`) still
-    /// segfaults. `emit_vec_push` memcpys `elem_size` bytes treating the
-    /// pushed operand as the source aggregate's ADDRESS, but
-    /// `eval_operand` on the bare call-result temp returns the call's
-    /// returned VALUE (the i64 `from_str` produced), not a stable
-    /// 16-byte `{ptr,len}` slot address. The fix needs the String-value
-    /// ABI threaded so an aggregate push sources from a real slot
-    /// address (and transfers ownership so drop doesn't double-free).
-    /// Minimal repro: `let mut v: Vec[String] = Vec.new();
-    /// v.push(String.from_str("a"))` — interp ok, JIT SIGSEGV.
+    ///   4. (v0.48 #297) Vec[String] element PUSH no longer SIGSEGVs for
+    ///      a valid String operand: `emit_vec_push` routes String/Str/
+    ///      Bytes elements through `string_pair` (correct for both the
+    ///      literal fast-path and the slot-backed case) instead of
+    ///      memcpy-from-operand-address. Validated: `Vec[String]` with
+    ///      literal pushes (`v.push("alpha")`) + `len()` now JIT-matches
+    ///      the interpreter. Lock-in tests in
+    ///      `crates/mty-codegen-cranelift/tests/vec_string_push_v048.rs`.
+    ///
+    /// REMAINING (still KNOWN_FAILING): native String codegen. The
+    /// examples build their strings via `String.from_str(...)` /
+    /// `with_capacity` / `new` and read them via `String.len()` /
+    /// `push_str` / `format!` — NONE of which have native cranelift
+    /// implementations (interp-only; `String.from_str` lowers to an
+    /// unhandled `BuiltinId::Extern` that yields garbage in JIT, so
+    /// `let s = String.from_str("a"); s.len()` gives interp 5 / JIT 0).
+    /// Flipping 26/42/43 needs the whole native-String surface, a
+    /// separate feature; this entry's fixes land the Vec-storage half.
     VecOfAggregate,
     /// v0.45 T1 native `std.fs` now actually touches disk under the
     /// JIT path. Examples that write to absolute hard-coded paths

--- a/crates/mty-codegen-cranelift/src/lower.rs
+++ b/crates/mty-codegen-cranelift/src/lower.rs
@@ -3782,17 +3782,38 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
         self.b.seal_block(cont_block);
         // Reload data (it may have changed in grow_block); len unchanged.
         let data = self.b.ins().load(ct::I64, mf, hdr, Self::VEC_DATA_OFF);
-        // The element source value: for scalars, the raw i64 value.
-        // For aggregates, the address (eval_operand returns the slot
-        // address when the type is_aggregate).
-        let raw = if let Some(a) = args.first() {
-            self.eval_operand(a)?
-        } else {
-            self.b.ins().iconst(ct::I64, 0)
-        };
         let byte_off = self.b.ins().imul_imm(len, elem_size);
         let slot = self.b.ins().iadd(data, byte_off);
-        self.vec_store_elem(slot, raw, elem_size, lds, elem_ty.as_ref());
+        // #297 layer 4 — String/Str/Bytes elements are a 16-byte
+        // (ptr@+0, len@+8) pair, but their operand is NOT a uniform
+        // slot address: a string literal materialises as an inline
+        // (ptr,len) pair (no slot) and `eval_operand` on a bare
+        // call-result temp returns the produced VALUE, not a 16-byte
+        // slot address. memcpy-from-operand-address therefore reads past
+        // a literal's bytes and corrupts the heap (segfault). Route
+        // these through `string_pair`, which yields the correct (ptr,len)
+        // for both the literal fast-path and the slot-backed dynamic
+        // case, and store both halves explicitly.
+        if matches!(
+            elem_ty.as_ref(),
+            Some(IrTy::String | IrTy::Str | IrTy::Bytes)
+        ) {
+            if let Some(a) = args.first() {
+                let (ptr, slen) = self.string_pair(a)?;
+                self.b.ins().store(mf, ptr, slot, 0);
+                self.b.ins().store(mf, slen, slot, 8);
+            }
+        } else {
+            // Scalars: the raw i64 value. Other aggregates: the slot
+            // address (eval_operand returns the address when the type
+            // is_aggregate), memcpy'd by `vec_store_elem`.
+            let raw = if let Some(a) = args.first() {
+                self.eval_operand(a)?
+            } else {
+                self.b.ins().iconst(ct::I64, 0)
+            };
+            self.vec_store_elem(slot, raw, elem_size, lds, elem_ty.as_ref());
+        }
         let new_len = self.b.ins().iadd_imm(len, 1);
         self.b.ins().store(mf, new_len, hdr, Self::VEC_LEN_OFF);
         Ok(hdr)

--- a/crates/mty-codegen-cranelift/tests/vec_string_push_v048.rs
+++ b/crates/mty-codegen-cranelift/tests/vec_string_push_v048.rs
@@ -1,0 +1,151 @@
+//! #297 layer 4 — Vec-of-String element-push JIT parity.
+//!
+//! A `Vec[String]` element is a 16-byte `(ptr@+0, len@+8)` pair, but a
+//! pushed String operand is NOT a uniform slot address: a string literal
+//! materialises as an inline `(ptr,len)` pair (no backing slot), so the
+//! old `emit_vec_push` path — which memcpy'd `elem_size` bytes treating
+//! the operand as the source aggregate's ADDRESS — read past the
+//! literal's bytes and corrupted the heap (SIGSEGV). The fix routes
+//! String/Str/Bytes elements through `string_pair` (correct for both the
+//! literal fast-path and the slot-backed dynamic case) and stores both
+//! halves explicitly.
+//!
+//! These tests push String *literals* (a valid String operand that does
+//! not depend on the still-unimplemented native `String.from_str` /
+//! `String.len()` surface) and read back the Vec length, which exercises
+//! the header + grow + element-store path end to end without crashing.
+
+use mty_ast::AstNode;
+use mty_codegen_cranelift::jit::{build_jit, symbols_from};
+use mty_ir::lower_package;
+use mty_syntax::parse;
+use std::alloc::{alloc, Layout};
+
+extern "C" fn no_op(_p: i64, _l: i64) {}
+extern "C" fn no_op_i64(_v: i64) {}
+extern "C" fn arena_push() -> i64 {
+    0
+}
+extern "C" fn arena_pop(_h: i64) {}
+extern "C" fn rt_alloc(size: i64, align: i64, _zero: i64) -> i64 {
+    let size = size.max(1) as usize;
+    let align = (align.max(1) as usize).next_power_of_two();
+    let layout = Layout::from_size_align(size, align).expect("valid layout");
+    // SAFETY: valid layout; intentionally leaked for the test's lifetime.
+    let p = unsafe { alloc(layout) };
+    p as i64
+}
+extern "C" fn budget_charge(_b: i64) -> i8 {
+    1
+}
+extern "C" fn extern_call(_n: i64, _l: i64, _a: i64) -> i64 {
+    0
+}
+extern "C" fn rt_send(_t: i64, _m: i64, _p: i64) {}
+extern "C" fn rt_ask(_t: i64, _m: i64, _p: i64, _d: i64) -> i64 {
+    0
+}
+extern "C" fn rt_spawn(_a: i64) -> i64 {
+    0
+}
+
+fn jit_run_i64(src: &str) -> Result<i64, String> {
+    let parsed = parse(src);
+    if !parsed.errors.is_empty() {
+        return Err(format!(
+            "parse errors: {:?}",
+            parsed.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+        ));
+    }
+    let file = mty_ast::File::cast(mty_syntax::SyntaxNode::new_root(parsed.green))
+        .ok_or_else(|| "FILE root not produced".to_string())?;
+    let (pkg, lower_diags) = mty_hir::lower::LoweringCtx::new().lower_file(file);
+    if let Some(d) = lower_diags
+        .iter()
+        .find(|d| matches!(d.severity, mty_diagnostics::Severity::Error))
+    {
+        return Err(format!("lower MT{:04}: {}", d.code.0, d.primary.message));
+    }
+    let typed = mty_types::check_package_typed(&pkg);
+    if let Some(d) = typed
+        .diagnostics
+        .iter()
+        .find(|d| matches!(d.severity, mty_diagnostics::Severity::Error))
+    {
+        return Err(format!("typeck MT{:04}: {}", d.code.0, d.primary.message));
+    }
+    let prog = lower_package(&pkg, &typed);
+    let syms = symbols_from(&[
+        ("mty_runtime_log", no_op as *const u8),
+        ("mty_runtime_print", no_op as *const u8),
+        ("mty_runtime_panic", no_op as *const u8),
+        ("mty_runtime_arena_push", arena_push as *const u8),
+        ("mty_runtime_arena_pop", arena_pop as *const u8),
+        ("mty_runtime_alloc", rt_alloc as *const u8),
+        ("mty_runtime_budget_charge", budget_charge as *const u8),
+        ("mty_runtime_send", rt_send as *const u8),
+        ("mty_runtime_ask", rt_ask as *const u8),
+        ("mty_runtime_spawn", rt_spawn as *const u8),
+        ("mty_runtime_extern_call", extern_call as *const u8),
+        ("mty_runtime_log_i64", no_op_i64 as *const u8),
+    ]);
+    let jc = build_jit(&prog, &syms).map_err(|e| format!("jit: {e:?}"))?;
+    Ok(jc.call_main().expect("main returns a value"))
+}
+
+fn must_run(src: &str) -> i64 {
+    jit_run_i64(src).unwrap_or_else(|e| panic!("compile/run failure: {e}\nsource:\n{src}"))
+}
+
+/// Pushing String literals into a `Vec[String]` must not corrupt the
+/// heap — pre-fix this SIGSEGV'd while sizing/storing the 16-byte
+/// element. The Vec length is the observable contract here.
+#[test]
+fn vec_of_string_literal_push_counts_correctly() {
+    let src = r#"
+fn main() -> I64 {
+  let mut v: Vec[String] = Vec.new()
+  v.push("alpha")
+  v.push("beta")
+  v.push("gamma")
+  v.len() as I64
+}
+"#;
+    assert_eq!(must_run(src), 3);
+}
+
+/// Growth across the initial capacity boundary (cap 0 → 4 → 8) with
+/// 16-byte aggregate elements: the grow-buffer must be sized by the real
+/// element width and the live prefix copied byte-granularly.
+#[test]
+fn vec_of_string_grows_past_capacity() {
+    let src = r#"
+fn main() -> I64 {
+  let mut v: Vec[String] = Vec.new()
+  v.push("a")
+  v.push("b")
+  v.push("c")
+  v.push("d")
+  v.push("e")
+  v.len() as I64
+}
+"#;
+    assert_eq!(must_run(src), 5);
+}
+
+/// Push-only inference (#297 layer 1): a `Vec` whose element is pinned
+/// only by `.push(x)` (no annotation) still sizes its scalar slots
+/// correctly and counts right.
+#[test]
+fn vec_push_only_inference_counts_correctly() {
+    let src = r#"
+fn main() -> I64 {
+  let mut v = Vec.new()
+  v.push(10_u32)
+  v.push(20_u32)
+  v.push(30_u32)
+  v.len() as I64
+}
+"#;
+    assert_eq!(must_run(src), 3);
+}

--- a/crates/mty-ir/src/lower/exprs.rs
+++ b/crates/mty-ir/src/lower/exprs.rs
@@ -30,7 +30,7 @@ pub fn lower_expr(ctx: &mut LowerCtx, fb: &mut FnBuilder, eid: ExprId) -> Operan
     match e {
         HirExpr::Literal(lit) => Operand::Const(lit_const(&lit)),
         HirExpr::Path(segments) => resolve_path(ctx, fb, &segments),
-        HirExpr::Call { callee, args } => lower_call(ctx, fb, callee, &args),
+        HirExpr::Call { callee, args } => lower_call(ctx, fb, eid, callee, &args),
         HirExpr::MethodCall {
             receiver,
             method,
@@ -736,7 +736,13 @@ fn builtin_for_name(name: &str) -> Option<BuiltinId> {
     })
 }
 
-fn lower_call(ctx: &mut LowerCtx, fb: &mut FnBuilder, callee: ExprId, args: &[HirArg]) -> Operand {
+fn lower_call(
+    ctx: &mut LowerCtx,
+    fb: &mut FnBuilder,
+    call_eid: ExprId,
+    callee: ExprId,
+    args: &[HirArg],
+) -> Operand {
     // v0.15 — variant-constructor call detection. `Some(42)`, `Ok(v)`,
     // `Result.Err(e)`, `Maybe.Just(x)`, etc. parse as a Call whose callee
     // resolves (via the type checker's def-map) to a variant constructor
@@ -931,9 +937,22 @@ fn lower_call(ctx: &mut LowerCtx, fb: &mut FnBuilder, callee: ExprId, args: &[Hi
     // package's per-expr type map when the result is a scalar. This
     // unblocks codegen typed dispatch (`log(double(21))` now knows
     // `double` returns I32 and routes to `mty_runtime_log_i32`).
-    // Aggregates still fall back to `IrTy::Error` — the existing
+    // Most aggregates still fall back to `IrTy::Error` — the existing
     // aggregate-slot path expects untyped temps.
-    let result_ty = scalar_call_result_ty(ctx, callee).unwrap_or(IrTy::Error);
+    //
+    // #297 — EXCEPT `Vec[T]` results (`Vec.new()`, `Vec.with_capacity()`).
+    // A Vec is a single header pointer (not a (ptr,len)-style slot
+    // aggregate), so typing its temp is safe, and it is REQUIRED:
+    // `let mut v = Vec.new()` lowers to `temp = Vec.new(); v = move temp`,
+    // and `emit_vec_new` reads the element size off `current_dest_ty` —
+    // i.e. the *temp's* type. If that's `Error`, the element slot falls
+    // back to 8 bytes, which silently corrupts the heap for aggregate
+    // elements (`Vec[String]`: 16-byte elements memcpy'd into 8-byte
+    // slots → segfault). Carrying the real `Vec[T]` onto the temp sizes
+    // the header correctly before `v` is ever bound.
+    let result_ty = scalar_call_result_ty(ctx, callee)
+        .or_else(|| vec_call_result_ty(ctx, call_eid))
+        .unwrap_or(IrTy::Error);
     let temp = fb.fresh_temp(result_ty);
     fb.push_stmt(Stmt::Assign(
         Place::local(temp),
@@ -992,6 +1011,26 @@ fn scalar_call_result_ty(ctx: &LowerCtx, callee: ExprId) -> Option<IrTy> {
         }
         _ => None,
     }
+}
+
+/// #297 — type a call-result temp with the call expression's own
+/// inferred `Vec[T]` type when it is one. Only `Vec` qualifies (a single
+/// header pointer, safe to type without disturbing the (ptr,len)
+/// aggregate-slot lazy-init path that other aggregate temps rely on).
+/// See the call site in `lower_call` for why this is load-bearing for
+/// `Vec`-of-aggregate element sizing.
+fn vec_call_result_ty(ctx: &LowerCtx, call_eid: ExprId) -> Option<IrTy> {
+    let tyid = ctx.typed.expr_ty.get(&call_eid).copied()?;
+    let lowered = super::ty::lower_ty(tyid, &ctx.typed.ty_arena);
+    if let IrTy::Adt(id, _) = &lowered {
+        if matches!(
+            ctx.typed.def_map.lookup("Vec"),
+            Some(DefRef::Adt(v)) if v == *id
+        ) {
+            return Some(lowered);
+        }
+    }
+    None
 }
 
 /// v0.15 — resolve a call's callee path to a variant constructor if

--- a/crates/mty-types/src/check.rs
+++ b/crates/mty-types/src/check.rs
@@ -903,6 +903,29 @@ fn synth_path(cx: &mut Cx, segments: &[String], expr_id: ExprId) -> TyId {
                     ));
                     return cx.arena.error;
                 }
+                // #297: static constructors on a generic opaque container
+                // (`Vec.new()`, `Vec.with_capacity(n)`) must synthesise
+                // `Vec[?E]` — an Adt with a fresh element var — NOT a bare
+                // fresh inference var. Otherwise the binding `let mut v =
+                // Vec.new()` has a `TyData::Var` receiver, so a later
+                // `v.push(x)` can't attach its element-coupling unification
+                // (which keys off an `Adt`-shaped receiver) and the element
+                // type is never inferred — lowering to `IrTy::Error` and the
+                // 8-byte cranelift element-slot fallback that corrupts the
+                // heap for aggregate elements. Scalar-aliased prelude types
+                // like `String` are NOT `DefRef::Adt`, so they never reach
+                // here and keep their primitive typing.
+                if adt.kind == AdtKind::Opaque
+                    && !adt.param_ids.is_empty()
+                    && matches!(vname.as_str(), "new" | "with_capacity")
+                {
+                    // Capture the arity first so the `adt` borrow of
+                    // `cx.defs` is released before we mutably borrow `cx`
+                    // via `cx.fresh()` / `cx.arena`.
+                    let nparams = adt.param_ids.len();
+                    let fresh_args: Vec<TyId> = (0..nparams).map(|_| cx.fresh()).collect();
+                    return cx.arena.adt(aid, fresh_args);
+                }
             }
         }
         // Opaque or arity-unmatched ADT chain: treat as opaque.
@@ -1264,7 +1287,55 @@ fn callee_param_has_nul_ok(cx: &Cx, callee: ExprId, idx: usize) -> bool {
     p.attrs.iter().any(|a| a == "ffi_nul_ok")
 }
 
+/// #297 — element-coupled `push`: unify the pushed value against the
+/// receiver's `Vec[E]` element type so a Vec whose element is never
+/// pinned by an annotation/return/param still infers its `T` from the
+/// pushed values. `recv_data` is the *resolved* receiver `TyData`.
+///
+/// Returns `Some(result_ty)` when it handled the call (receiver is a
+/// generic container with at least one type arg and exactly one value
+/// was pushed); `None` otherwise so the caller keeps its default path.
+///
+/// Without this, a push-only Vec keeps its element as an unresolved
+/// inference var → `IrTy::Error` → cranelift's 8-byte element-slot
+/// fallback → heap corruption (segfault) for aggregate elements
+/// (`String`, structs). `String.push(ch)` etc. are unaffected: `String`
+/// is a primitive alias, not a `TyData::Adt`, so it never matches here.
+fn try_push_elem_unify(cx: &mut Cx, recv_data: &TyData, args: &[HirArg]) -> Option<TyId> {
+    if args.len() != 1 {
+        return None;
+    }
+    if let TyData::Adt(_, adt_args) = recv_data {
+        if let Some(elem) = adt_args.first().copied() {
+            check_expr(cx, args[0].value, elem);
+            return Some(cx.fresh());
+        }
+    }
+    None
+}
+
 fn synth_call(cx: &mut Cx, callee: ExprId, args: &[HirArg], expr_id: ExprId) -> TyId {
+    // #297 — `v.push(x)` lowers to `Call { callee: Field{v,"push"}, args }`
+    // (NOT `MethodCall`), so it would otherwise land in the permissive
+    // Var-callee arm below where the arg is synthesised then discarded —
+    // the value type never unifies with the receiver's `Vec[E]` element.
+    // Intercept the element-coupled `push` here so a push-only Vec infers
+    // its element type. See `try_push_elem_unify` for why this matters
+    // (8-byte element-slot fallback → heap corruption otherwise).
+    if let HirExpr::Field { receiver, name } = &cx.pkg.exprs[callee] {
+        if name == "push" && args.len() == 1 {
+            let receiver = *receiver;
+            // Synthesise the callee too, so `expr_ty(callee)` is still
+            // recorded for downstream lowering (matches the normal path).
+            let _ = synth_expr(cx, callee);
+            let recv_ty = synth_expr(cx, receiver);
+            let resolved = cx.subst.resolve(recv_ty, cx.arena);
+            let recv_data = cx.arena.get(resolved).clone();
+            if let Some(ret) = try_push_elem_unify(cx, &recv_data, args) {
+                return ret;
+            }
+        }
+    }
     // v0.47 T4 — removed-stdlib deny check for qualified path calls.
     // `std.fs.read_dir_lines(p)` is a `Call` whose callee is the path
     // `std.fs.read_dir_lines`; that callee otherwise resolves
@@ -1587,8 +1658,30 @@ fn synth_method_call(
         // Opaque ADT: fall through to permissive paths below.
     }
 
-    // 2. Built-in method table: permissive — accept any arity, return fresh.
+    // 2. Built-in method table: permissive on arity / return type, but a
+    //    few methods are *element-coupled* and must thread the receiver's
+    //    generic element type or inference silently drops it.
+    //
+    //    `vec.push(x)` is the load-bearing case (#297). The permissive
+    //    table otherwise just `synth`s + discards each arg, so the value
+    //    type never unifies with the receiver's element parameter. A Vec
+    //    whose element is never pinned by an annotation, an annotated
+    //    return, or an annotated param (e.g. a push-only local that the
+    //    fn returns as a non-Vec) then keeps its element as an unresolved
+    //    inference var. That lowers to `IrTy::Error`, and cranelift's
+    //    Vec storage falls back to an 8-byte element slot regardless of
+    //    the real `T` size — so pushing/reading an aggregate element
+    //    (`String`, a struct) memcpys the wrong stride and corrupts the
+    //    heap (segfault). Unifying the pushed value against the element
+    //    var here is the missing constraint; everything downstream (the
+    //    v0.39 T3 / v0.48 T1 binding-slot carve-out, the typed-slot
+    //    codegen) already does the right thing once `T` is known.
     if cx.defs.builtin_methods.contains_key(method) {
+        if method == "push" {
+            if let Some(ret) = try_push_elem_unify(cx, &data, args) {
+                return ret;
+            }
+        }
         for arg in args {
             let _ = synth_expr(cx, arg.value);
         }


### PR DESCRIPTION
Diagnosed the `Vec`-of-aggregate JIT segfault (conformance examples 26/42/43) as a **layered** defect and fixed the tractable layers. All changes regression-free, validated locally (full `mty-codegen-cranelift` suite + conformance sweep + passing-floor) **and on vulcan's full workspace suite: 3894 passed, 0 failed**.

## Fixed

1. **Push-only element inference** (`mty-types/check.rs`): `Vec.new()`/`with_capacity()` now synth `Vec[?E]`, and `push(x)` unifies `x` with the element var `E` (`try_push_elem_unify`, applied in `synth_call`'s `Field`-callee path — where `v.push(x)` actually lands as `Call{Field}` — and `synth_method_call`). A Vec whose element is pinned only by `.push(x)` now infers `T`. `String.push(ch)` is unaffected (String is a primitive alias, not an Adt).

2. **`Vec.new()` result-temp typing** (`mty-ir/lower/exprs.rs` `vec_call_result_ty`): the constructor temp was `IrTy::Error`, so `emit_vec_new` sized the header element slot at the 8-byte fallback even for `Vec[String]` (16). The temp now carries the real `Vec[T]`. CLIF-verified: header `elem_size=16`, grow-alloc + element store use the correct width.

3. **Vec[String] element-push SIGSEGV** (`mty-codegen-cranelift/src/lower.rs` `emit_vec_push`): a String element is a 16-byte `(ptr,len)` pair, but the pushed operand isn't a uniform slot address (a string literal is an inline `(ptr,len)` pair; `eval_operand` on a bare call-result temp returns a value). The old memcpy-from-operand-address read past a literal's bytes → heap corruption. Now routed through `string_pair` (correct for both literal and slot cases). Validated: `v.push("alpha")` + `len()` JIT-matches the interpreter (was a segfault). Lock-in tests in `tests/vec_string_push_v048.rs`.

## Not yet flipped (still KNOWN_FAILING): examples 26/42/43

They build strings via `String.from_str(...)`/`with_capacity`/`new` and read them via `String.len()`/`push_str`/`format!` — **none have native cranelift implementations** (interp-only; `String.from_str` lowers to an unhandled `BuiltinId::Extern` that yields garbage in JIT — `let s = String.from_str("a"); s.len()` gives interp 5 / JIT 0). Flipping the examples needs the **whole native-String surface**, a separate feature tracked as the remaining #297 work. This PR lands the Vec-storage half correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)