### PR TITLE
v0.48: native String constructors — fix example 26 (#297)

### DIFF
--- a/crates/mty-cli/tests/conformance_examples.rs
+++ b/crates/mty-cli/tests/conformance_examples.rs
@@ -179,10 +179,9 @@ const KNOWN_FAILING: &[KnownFailing] = &[
         name: "19_backend_service",
         reason: KnownReason::MainTakesCapabilities,
     },
-    KnownFailing {
-        name: "26_string_vec",
-        reason: KnownReason::VecOfAggregate,
-    },
+    // 26_string_vec FIXED in v0.48 (#297): Vec-of-aggregate sizing/push
+    // + native String constructors (new/with_capacity/from_str) make it
+    // JIT-match the interpreter.
     KnownFailing {
         name: "42_crypto_url",
         reason: KnownReason::VecOfAggregate,

--- a/crates/mty-codegen-cranelift/src/lower.rs
+++ b/crates/mty-codegen-cranelift/src/lower.rs
@@ -2406,6 +2406,30 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
                 }
                 self.emit_str_concat(&args[0], &args[1])
             }
+            // #297 — native String constructors. `String` is a 16-byte
+            // (ptr@+0, len@+8) aggregate shared with `Str`, so:
+            //   * `String.from_str(s)` is identity — materialise the
+            //     argument's (ptr,len) into a fresh String slot.
+            //   * `String.new()` / `String.with_capacity(n)` produce an
+            //     empty String (ptr=0, len=0); the capacity hint is a
+            //     no-op in the JIT (growth reallocates on demand).
+            // Without these, the path-call resolved to an unhandled
+            // `Extern("String.…")` symbol and yielded garbage (a
+            // `Vec[String]` built from `from_str` then SIGSEGV'd, and
+            // `String.from_str(x).len()` read 0).
+            FnRef::Builtin(BuiltinId::Extern(name)) if name == "String.from_str" => {
+                let arg = args
+                    .first()
+                    .ok_or_else(|| CodegenError::Unsupported("String.from_str arity 0".into()))?;
+                let (ptr, len) = self.string_pair(arg)?;
+                Ok(self.emit_string_slot(ptr, len))
+            }
+            FnRef::Builtin(BuiltinId::Extern(name))
+                if name == "String.new" || name == "String.with_capacity" =>
+            {
+                let zero = self.b.ins().iconst(ct::I64, 0);
+                Ok(self.emit_string_slot(zero, zero))
+            }
             FnRef::User(callee_id) => {
                 let func_id = *self.mod_ctx.fn_ids.get(callee_id).ok_or_else(|| {
                     CodegenError::Module(format!("call to undeclared fn {:?}", callee_id))
@@ -3178,6 +3202,28 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
             None,
         )?;
         Ok(slot_addr)
+    }
+
+    /// #297 — materialise a `String` aggregate: a fresh 16-byte stack
+    /// slot holding `(ptr@+0, len@+8)`. Returns the slot address (the
+    /// String value's by-address representation). Used by the native
+    /// String constructors (`String.new`, `String.with_capacity`,
+    /// `String.from_str`).
+    fn emit_string_slot(
+        &mut self,
+        ptr: cranelift_codegen::ir::Value,
+        len: cranelift_codegen::ir::Value,
+    ) -> cranelift_codegen::ir::Value {
+        let slot = self.b.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            16,
+            3, // log2(8)
+        ));
+        let slot_addr = self.b.ins().stack_addr(ct::I64, slot, 0);
+        let mf = MemFlags::trusted();
+        self.b.ins().store(mf, ptr, slot_addr, 0);
+        self.b.ins().store(mf, len, slot_addr, 8);
+        slot_addr
     }
 
     /// v0.42 T4 (L23 fix) — `n.to_str()` on a scalar receiver.

--- a/crates/mty-codegen-cranelift/tests/vec_string_push_v048.rs
+++ b/crates/mty-codegen-cranelift/tests/vec_string_push_v048.rs
@@ -149,3 +149,39 @@ fn main() -> I64 {
 "#;
     assert_eq!(must_run(src), 3);
 }
+
+/// #297 — native `String.from_str` is identity on the `(ptr,len)` pair.
+/// Building a `Vec[String]` from `from_str(...)` results (no annotation,
+/// element inferred from the pushed Strings) must not crash and must
+/// count correctly — this is the exact `_make_name_list` shape from
+/// example 26 that previously SIGSEGV'd (from_str yielded garbage that
+/// the element push then dereferenced).
+#[test]
+fn vec_of_string_from_str_builds_and_counts() {
+    let src = r#"
+fn main() -> I64 {
+  let mut v = Vec.new()
+  v.push(String.from_str("alpha"))
+  v.push(String.from_str("beta"))
+  v.push(String.from_str("gamma"))
+  v.len() as I64
+}
+"#;
+    assert_eq!(must_run(src), 3);
+}
+
+/// `String.new()` / `String.with_capacity(n)` produce an empty String
+/// (ptr=0, len=0) without crashing; pushing them into a Vec and counting
+/// exercises the empty-String materialisation + 16-byte element store.
+#[test]
+fn vec_of_empty_strings_counts() {
+    let src = r#"
+fn main() -> I64 {
+  let mut v: Vec[String] = Vec.new()
+  v.push(String.new())
+  v.push(String.with_capacity(16))
+  v.len() as I64
+}
+"#;
+    assert_eq!(must_run(src), 2);
+}


### PR DESCRIPTION
Builds on the merged Vec-of-aggregate fixes (#38) to add **native cranelift String constructors**, flipping the first VecOfAggregate conformance example to passing.

## Problem
`String` is a 16-byte `(ptr@+0, len@+8)` aggregate (shared with `Str`), but its constructors had **no cranelift codegen** — the path-calls resolved to unhandled `Extern("String.…")` symbols that yielded garbage. So a `Vec[String]` built from `String.from_str(...)` SIGSEGV'd (the element push dereferenced garbage), and `String.from_str(x).len()` read 0.

## Fix (`mty-codegen-cranelift/src/lower.rs`)
Native lowering in `emit_call` + an `emit_string_slot` helper:
- **`String.from_str(s)`** — identity: materialise the `Str` arg's `(ptr,len)` into a fresh 16-byte String slot.
- **`String.new()` / `String.with_capacity(n)`** — empty String `(0,0)`; capacity is a JIT no-op (growth reallocates on demand).

## Result
**Example 26 (`26_string_vec`) now JIT-matches the interpreter** — removed from `KNOWN_FAILING`. Validated:
- Local: full `mty-codegen-cranelift` suite + conformance sweep + passing-floor green; 5 lock-in tests in `vec_string_push_v048.rs`.
- **vulcan**: full `cargo test --workspace` exit 0, **conformance with `--features host-toolchain`: 3 passed / 0 failed** (incl. the sweep with 26 now passing).

## Still KNOWN_FAILING (broader native surface, follow-up)
`42_crypto_url`, `43_secure_session` — pull in `std.crypto`/`encoding`/`url`/`uuid`/`regex` + AEAD and String *methods* (`push_str`/`format!`/`len`), none of which have native cranelift implementations yet (interp-only). `String.len()` still returns 0 in JIT (no native method dispatch); example 26 doesn't observe it (results discarded). Those are the remaining native-stdlib work for #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)