### PR TITLE
v0.49: native std.crypto + std.encoding codegen

### DIFF
--- a/crates/mty-codegen-cranelift/src/lower.rs
+++ b/crates/mty-codegen-cranelift/src/lower.rs
@@ -990,6 +990,28 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
                     let out = out.clone();
                     return self.emit_fs_call(&full_name, &args, out.as_ref());
                 }
+                // v0.49 — native std.crypto / std.encoding. Each call
+                // takes `(ptr,len)` input(s) and writes a `(ptr,len)`
+                // result aggregate (Bytes for digests, String for
+                // encoders) into a fresh 16-byte slot. Without this the
+                // call hit the `mty_runtime_extern_call` stub that
+                // returns 0, and a downstream `hex.encode(0)` dereffed
+                // null → SIGSEGV (examples 42/43).
+                if is_native_crypto_encoding(&full_name) {
+                    let args = args.clone();
+                    let out = out.clone();
+                    let result = self.emit_crypto_encoding_call(&full_name, &args)?;
+                    if let Some(p) = out {
+                        if !p.proj.is_empty() {
+                            let (addr, ty) = self.place_addr(&p)?;
+                            self.store_scalar(addr, result, &ty)?;
+                        } else {
+                            let var = self.ensure_var(p.local);
+                            self.b.def_var(var, result);
+                        }
+                    }
+                    return Ok(());
+                }
                 if is_interpreter_hosted_stdlib(&full_name) {
                     return Err(CodegenError::Unsupported(format!(
                         "{full_name} is interpreter-hosted"
@@ -3011,6 +3033,53 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
         }
     }
 
+    /// v0.49 — lower a native `std.crypto` / `std.encoding` call. Each
+    /// maps to a runtime ABI symbol that takes its `(ptr,len)` input(s)
+    /// and writes a `(ptr,len)` result aggregate into a fresh 16-byte
+    /// slot. Returns the slot address (a Bytes/String value).
+    fn emit_crypto_encoding_call(
+        &mut self,
+        full_name: &str,
+        args: &[Operand],
+    ) -> CompileResult<cranelift_codegen::ir::Value> {
+        let bare = full_name.strip_prefix("std.").unwrap_or(full_name);
+        // (runtime symbol, number of `(ptr,len)` data inputs)
+        let (symbol, n_inputs): (&str, usize) = match bare {
+            "crypto.sha256" => ("mty_runtime_crypto_sha256", 1),
+            "crypto.sha512" => ("mty_runtime_crypto_sha512", 1),
+            "crypto.blake3" => ("mty_runtime_crypto_blake3", 1),
+            "crypto.hmac_sha256" => ("mty_runtime_crypto_hmac_sha256", 2),
+            "encoding.hex.encode" => ("mty_runtime_encoding_hex_encode", 1),
+            "encoding.base64.encode" => ("mty_runtime_encoding_base64_encode", 1),
+            "encoding.base64.encode_url_no_pad" => {
+                ("mty_runtime_encoding_base64_encode_url_no_pad", 1)
+            }
+            other => {
+                return Err(CodegenError::Unsupported(format!(
+                    "native crypto/encoding dispatch missing for {other}"
+                )))
+            }
+        };
+        // Each input operand (a Str/Bytes aggregate) expands to a
+        // `(ptr, len)` pair via `string_pair` (handles literals + slots).
+        let mut call_args = Vec::with_capacity(n_inputs * 2 + 1);
+        for a in args.iter().take(n_inputs) {
+            let (ptr, len) = self.string_pair(a)?;
+            call_args.push(ptr);
+            call_args.push(len);
+        }
+        // Fresh 16-byte (ptr@+0, len@+8) result slot.
+        let slot = self.b.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            16,
+            3, // log2(8)
+        ));
+        let slot_addr = self.b.ins().stack_addr(ct::I64, slot, 0);
+        call_args.push(slot_addr);
+        self.call_rt(symbol, &call_args, None)?;
+        Ok(slot_addr)
+    }
+
     /// v0.45 T1 (L18 fix) — lower a `std.fs.*` call to its native
     /// runtime ABI symbol.
     ///
@@ -4360,6 +4429,23 @@ fn is_interpreter_hosted_stdlib(name: &str) -> bool {
 /// frontend dispatch table. The runtime symbol `mty_runtime_fs_read_dir`
 /// stays live so v0.45-built binaries still link; the codegen just no
 /// longer routes anything to it.
+/// v0.49 — true for the `std.crypto.*` / `std.encoding.*` calls that
+/// have a native Cranelift lowering (`emit_crypto_encoding_call`). Kept
+/// in sync with that match.
+fn is_native_crypto_encoding(full_name: &str) -> bool {
+    let bare = full_name.strip_prefix("std.").unwrap_or(full_name);
+    matches!(
+        bare,
+        "crypto.sha256"
+            | "crypto.sha512"
+            | "crypto.blake3"
+            | "crypto.hmac_sha256"
+            | "encoding.hex.encode"
+            | "encoding.base64.encode"
+            | "encoding.base64.encode_url_no_pad"
+    )
+}
+
 fn is_native_fs_method(full_name: &str) -> bool {
     fn strip(s: &str) -> &str {
         s.strip_prefix("std.").unwrap_or(s)

--- a/crates/mty-codegen-cranelift/src/runtime_imports.rs
+++ b/crates/mty-codegen-cranelift/src/runtime_imports.rs
@@ -204,6 +204,43 @@ pub const RUNTIME_IMPORTS: &[RuntimeImport] = &[
         params: &[ct::I64, ct::I64, ct::I64, ct::I64, ct::I64],
         ret: None,
     },
+    // v0.49 — native std.crypto / std.encoding. Digests + encoders take
+    // their `(ptr,len)` input(s) plus a result-slot pointer.
+    RuntimeImport {
+        name: "mty_runtime_crypto_sha256",
+        params: &[ct::I64, ct::I64, ct::I64],
+        ret: None,
+    },
+    RuntimeImport {
+        name: "mty_runtime_crypto_sha512",
+        params: &[ct::I64, ct::I64, ct::I64],
+        ret: None,
+    },
+    RuntimeImport {
+        name: "mty_runtime_crypto_blake3",
+        params: &[ct::I64, ct::I64, ct::I64],
+        ret: None,
+    },
+    RuntimeImport {
+        name: "mty_runtime_crypto_hmac_sha256",
+        params: &[ct::I64, ct::I64, ct::I64, ct::I64, ct::I64],
+        ret: None,
+    },
+    RuntimeImport {
+        name: "mty_runtime_encoding_hex_encode",
+        params: &[ct::I64, ct::I64, ct::I64],
+        ret: None,
+    },
+    RuntimeImport {
+        name: "mty_runtime_encoding_base64_encode",
+        params: &[ct::I64, ct::I64, ct::I64],
+        ret: None,
+    },
+    RuntimeImport {
+        name: "mty_runtime_encoding_base64_encode_url_no_pad",
+        params: &[ct::I64, ct::I64, ct::I64],
+        ret: None,
+    },
     // v0.45 T1 — native std.fs surface (L18 fix).
     // read / read_to_string / read_dir: (path_ptr, path_len, dst_slot)
     // write the (ptr, len, ok) triple into a caller-supplied 24-byte

--- a/crates/mty-driver/tests/extern_c_matrix.rs
+++ b/crates/mty-driver/tests/extern_c_matrix.rs
@@ -226,6 +226,15 @@ int32_t mty_runtime_fs_remove_dir_all(int64_t p, int64_t pl) { (void)p; (void)pl
 int64_t mty_runtime_fs_dir_open(int64_t p, int64_t pl) { (void)p; (void)pl; return 0; }
 int32_t mty_runtime_fs_dir_next(int64_t h, int64_t d) { (void)h; (void)d; return 0; }
 void mty_runtime_fs_dir_close(int64_t h) { (void)h; }
+/* v0.49 — native std.crypto / std.encoding imports. Same MSVC rule:
+ * the codegen references every runtime import, so each needs a stub. */
+void mty_runtime_crypto_sha256(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_crypto_sha512(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_crypto_blake3(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_crypto_hmac_sha256(int64_t k, int64_t kl, int64_t m, int64_t ml, int64_t dst) { (void)k; (void)kl; (void)m; (void)ml; (void)dst; }
+void mty_runtime_encoding_hex_encode(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_encoding_base64_encode(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_encoding_base64_encode_url_no_pad(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
 "#,
     )
     .unwrap();

--- a/crates/mty-driver/tests/fs_native_v045_t1.rs
+++ b/crates/mty-driver/tests/fs_native_v045_t1.rs
@@ -364,6 +364,15 @@ int32_t mty_runtime_fs_dir_next(int64_t handle, int64_t dst) {
     (void)handle; (void)dst; return 0;
 }
 void mty_runtime_fs_dir_close(int64_t handle) { (void)handle; }
+/* v0.49 — native std.crypto / std.encoding imports. Same MSVC rule:
+ * the codegen references every runtime import, so each needs a stub. */
+void mty_runtime_crypto_sha256(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_crypto_sha512(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_crypto_blake3(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_crypto_hmac_sha256(int64_t k, int64_t kl, int64_t m, int64_t ml, int64_t dst) { (void)k; (void)kl; (void)m; (void)ml; (void)dst; }
+void mty_runtime_encoding_hex_encode(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_encoding_base64_encode(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_encoding_base64_encode_url_no_pad(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
 "#;
 
 fn build_runtime_archive(work_dir: &Path, cc: &str, ar: &str) -> PathBuf {

--- a/crates/mty-driver/tests/vec_liveness_native_v042.rs
+++ b/crates/mty-driver/tests/vec_liveness_native_v042.rs
@@ -243,6 +243,15 @@ void repro_print_i64(int64_t tag, int64_t value) {
 int64_t mty_runtime_fs_dir_open(int64_t p, int64_t pl) { (void)p; (void)pl; return 0; }
 int32_t mty_runtime_fs_dir_next(int64_t h, int64_t d) { (void)h; (void)d; return 0; }
 void mty_runtime_fs_dir_close(int64_t h) { (void)h; }
+/* v0.49 — native std.crypto / std.encoding imports. Same MSVC rule:
+ * the codegen references every runtime import, so each needs a stub. */
+void mty_runtime_crypto_sha256(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_crypto_sha512(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_crypto_blake3(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_crypto_hmac_sha256(int64_t k, int64_t kl, int64_t m, int64_t ml, int64_t dst) { (void)k; (void)kl; (void)m; (void)ml; (void)dst; }
+void mty_runtime_encoding_hex_encode(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_encoding_base64_encode(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
+void mty_runtime_encoding_base64_encode_url_no_pad(int64_t d, int64_t dl, int64_t dst) { (void)d; (void)dl; (void)dst; }
 "#,
     )
     .unwrap();

--- a/crates/mty-runtime/Cargo.toml
+++ b/crates/mty-runtime/Cargo.toml
@@ -28,6 +28,14 @@ tokio.workspace = true
 tokio-util = { workspace = true, features = ["time", "rt"] }
 parking_lot.workspace = true
 dashmap.workspace = true
+# v0.49 — native std.crypto / std.encoding codegen ABI. Same crates
+# mty-stdlib uses for the interpreter path; depending on them directly
+# (not on mty-stdlib) keeps the runtime free of a dependency cycle.
+sha2.workspace = true
+hex.workspace = true
+hmac = "0.12"
+base64 = "0.22"
+blake3 = { version = "1", default-features = false, features = ["std"] }
 thiserror.workspace = true
 bumpalo.workspace = true
 libloading.workspace = true

--- a/crates/mty-runtime/include/mty_runtime_abi.h
+++ b/crates/mty-runtime/include/mty_runtime_abi.h
@@ -139,6 +139,20 @@ int32_t mty_runtime_fs_dir_next(int64_t handle, int64_t dst);
 void mty_runtime_fs_dir_close(int64_t handle);
 /* @since 0.42.0 */
 void mty_runtime_str_concat(int64_t aptr, int64_t alen, int64_t bptr, int64_t blen, int64_t dst);
+/* @since 0.49.0 */
+void mty_runtime_crypto_sha256(int64_t data_ptr, int64_t data_len, int64_t dst);
+/* @since 0.49.0 */
+void mty_runtime_crypto_sha512(int64_t data_ptr, int64_t data_len, int64_t dst);
+/* @since 0.49.0 */
+void mty_runtime_crypto_blake3(int64_t data_ptr, int64_t data_len, int64_t dst);
+/* @since 0.49.0 */
+void mty_runtime_crypto_hmac_sha256(int64_t key_ptr, int64_t key_len, int64_t msg_ptr, int64_t msg_len, int64_t dst);
+/* @since 0.49.0 */
+void mty_runtime_encoding_hex_encode(int64_t data_ptr, int64_t data_len, int64_t dst);
+/* @since 0.49.0 */
+void mty_runtime_encoding_base64_encode(int64_t data_ptr, int64_t data_len, int64_t dst);
+/* @since 0.49.0 */
+void mty_runtime_encoding_base64_encode_url_no_pad(int64_t data_ptr, int64_t data_len, int64_t dst);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/crates/mty-runtime/src/codegen_abi.rs
+++ b/crates/mty-runtime/src/codegen_abi.rs
@@ -188,6 +188,12 @@ thread_local! {
     /// underlying allocation — no reallocation can move the bytes out
     /// from under the caller's pointer.
     static FMT_STRINGS: RefCell<Vec<Box<str>>> = const { RefCell::new(Vec::new()) };
+
+    /// v0.49 — owned raw-byte buffers produced by the native
+    /// `std.crypto.*` digests. Same lifetime contract as `FMT_STRINGS`:
+    /// the `Box<[u8]>` freezes the allocation so the `(ptr, len)` we
+    /// hand back stays valid for the program's lifetime.
+    static FMT_BYTES: RefCell<Vec<Box<[u8]>>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Intern an owned string into the per-thread `FMT_STRINGS` table and
@@ -810,6 +816,110 @@ pub extern "C" fn mty_runtime_str_concat(aptr: i64, alen: i64, bptr: i64, blen: 
     unsafe { write_str_pair(dst, p, l) };
 }
 
+// ---- v0.49 native std.crypto / std.encoding -------------------------
+//
+// Each fn reads its `(ptr, len)` input(s), computes the result with the
+// same RustCrypto crate the interpreter (`mty-stdlib`) uses, interns the
+// result so the returned pointer outlives the call, and writes a
+// `(ptr, len)` pair into the caller's 16-byte slot. Digest results are
+// `Bytes` (raw bytes); encoders return a `String`. Both share the
+// `(ptr, len)` aggregate the codegen already understands, so a
+// `hex.encode(sha256(x))` chain pipes straight through.
+
+/// Intern raw bytes into a per-thread frozen table; returns `(ptr, len)`.
+/// Unlike `intern_bytes`, this does NOT go through a lossy UTF-8
+/// round-trip — digest output must survive byte-for-byte.
+fn intern_raw_bytes(bytes: Vec<u8>) -> (i64, i64) {
+    FMT_BYTES.with(|t| {
+        let boxed: Box<[u8]> = bytes.into_boxed_slice();
+        let ptr = boxed.as_ptr() as i64;
+        let len = boxed.len() as i64;
+        t.borrow_mut().push(boxed);
+        (ptr, len)
+    })
+}
+
+// @since 0.49.0
+#[no_mangle]
+pub extern "C" fn mty_runtime_crypto_sha256(data_ptr: i64, data_len: i64, dst: i64) {
+    use sha2::Digest;
+    let data = unsafe { read_bytes(data_ptr, data_len) };
+    let digest = sha2::Sha256::digest(data);
+    let (p, l) = intern_raw_bytes(digest.to_vec());
+    unsafe { write_str_pair(dst, p, l) };
+}
+
+// @since 0.49.0
+#[no_mangle]
+pub extern "C" fn mty_runtime_crypto_sha512(data_ptr: i64, data_len: i64, dst: i64) {
+    use sha2::Digest;
+    let data = unsafe { read_bytes(data_ptr, data_len) };
+    let digest = sha2::Sha512::digest(data);
+    let (p, l) = intern_raw_bytes(digest.to_vec());
+    unsafe { write_str_pair(dst, p, l) };
+}
+
+// @since 0.49.0
+#[no_mangle]
+pub extern "C" fn mty_runtime_crypto_blake3(data_ptr: i64, data_len: i64, dst: i64) {
+    let data = unsafe { read_bytes(data_ptr, data_len) };
+    let hash = blake3::hash(data);
+    let (p, l) = intern_raw_bytes(hash.as_bytes().to_vec());
+    unsafe { write_str_pair(dst, p, l) };
+}
+
+// @since 0.49.0
+#[no_mangle]
+pub extern "C" fn mty_runtime_crypto_hmac_sha256(
+    key_ptr: i64,
+    key_len: i64,
+    msg_ptr: i64,
+    msg_len: i64,
+    dst: i64,
+) {
+    use hmac::Mac;
+    let key = unsafe { read_bytes(key_ptr, key_len) };
+    let msg = unsafe { read_bytes(msg_ptr, msg_len) };
+    let mut mac =
+        <hmac::Hmac<sha2::Sha256> as hmac::Mac>::new_from_slice(key).expect("hmac key any size");
+    mac.update(msg);
+    let tag = mac.finalize().into_bytes();
+    let (p, l) = intern_raw_bytes(tag.to_vec());
+    unsafe { write_str_pair(dst, p, l) };
+}
+
+// @since 0.49.0
+#[no_mangle]
+pub extern "C" fn mty_runtime_encoding_hex_encode(data_ptr: i64, data_len: i64, dst: i64) {
+    let data = unsafe { read_bytes(data_ptr, data_len) };
+    let (p, l) = intern_fmt(hex::encode(data));
+    unsafe { write_str_pair(dst, p, l) };
+}
+
+// @since 0.49.0
+#[no_mangle]
+pub extern "C" fn mty_runtime_encoding_base64_encode(data_ptr: i64, data_len: i64, dst: i64) {
+    use base64::Engine;
+    let data = unsafe { read_bytes(data_ptr, data_len) };
+    let s = base64::engine::general_purpose::STANDARD.encode(data);
+    let (p, l) = intern_fmt(s);
+    unsafe { write_str_pair(dst, p, l) };
+}
+
+// @since 0.49.0
+#[no_mangle]
+pub extern "C" fn mty_runtime_encoding_base64_encode_url_no_pad(
+    data_ptr: i64,
+    data_len: i64,
+    dst: i64,
+) {
+    use base64::Engine;
+    let data = unsafe { read_bytes(data_ptr, data_len) };
+    let s = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(data);
+    let (p, l) = intern_fmt(s);
+    unsafe { write_str_pair(dst, p, l) };
+}
+
 // ---- helpers --------------------------------------------------------
 
 /// SAFETY: `ptr` must point to `len` valid utf-8 bytes that outlive
@@ -822,6 +932,16 @@ unsafe fn read_str<'a>(ptr: i64, len: i64) -> &'a str {
     let p = ptr as usize as *const u8;
     let slice = std::slice::from_raw_parts(p, len as usize);
     std::str::from_utf8_unchecked(slice)
+}
+
+/// SAFETY: `ptr` must point to `len` valid bytes that outlive this call
+/// (a `.rodata` literal or an interned aggregate). Returns an empty
+/// slice for a null/empty input.
+unsafe fn read_bytes<'a>(ptr: i64, len: i64) -> &'a [u8] {
+    if ptr == 0 || len <= 0 {
+        return &[];
+    }
+    std::slice::from_raw_parts(ptr as usize as *const u8, len as usize)
 }
 
 /// Build the (name, address) symbol table for the JIT linker.
@@ -871,6 +991,26 @@ pub fn symbol_table() -> Vec<(String, *const u8)> {
         entry!("mty_runtime_fmt_f64", mty_runtime_fmt_f64),
         entry!("mty_runtime_fmt_bool", mty_runtime_fmt_bool),
         entry!("mty_runtime_str_concat", mty_runtime_str_concat),
+        // v0.49 — native std.crypto / std.encoding
+        entry!("mty_runtime_crypto_sha256", mty_runtime_crypto_sha256),
+        entry!("mty_runtime_crypto_sha512", mty_runtime_crypto_sha512),
+        entry!("mty_runtime_crypto_blake3", mty_runtime_crypto_blake3),
+        entry!(
+            "mty_runtime_crypto_hmac_sha256",
+            mty_runtime_crypto_hmac_sha256
+        ),
+        entry!(
+            "mty_runtime_encoding_hex_encode",
+            mty_runtime_encoding_hex_encode
+        ),
+        entry!(
+            "mty_runtime_encoding_base64_encode",
+            mty_runtime_encoding_base64_encode
+        ),
+        entry!(
+            "mty_runtime_encoding_base64_encode_url_no_pad",
+            mty_runtime_encoding_base64_encode_url_no_pad
+        ),
         // v0.45 T1 — native std.fs surface (L18 fix).
         entry!("mty_runtime_fs_read", mty_runtime_fs_read),
         entry!(
@@ -932,6 +1072,94 @@ mod tests {
     fn read_str_handles_null() {
         let s = unsafe { read_str(0, 0) };
         assert!(s.is_empty());
+    }
+
+    // ---- v0.49 — native std.crypto / std.encoding ABI tests --------
+
+    /// Read a `(ptr, len)` slot back into an owned byte vec.
+    fn slot_bytes(slot: &[i64; 2]) -> Vec<u8> {
+        let (ptr, len) = (slot[0], slot[1]);
+        unsafe { read_bytes(ptr, len).to_vec() }
+    }
+
+    #[test]
+    fn crypto_sha256_then_hex_encode_matches_known_vector() {
+        let data = b"hello";
+        // sha256("hello") -> 32 raw bytes
+        let mut digest_slot = [0i64; 2];
+        mty_runtime_crypto_sha256(
+            data.as_ptr() as i64,
+            data.len() as i64,
+            digest_slot.as_mut_ptr() as i64,
+        );
+        assert_eq!(digest_slot[1], 32, "sha256 digest is 32 bytes");
+        // hex.encode(digest) -> 64-char String
+        let mut hex_slot = [0i64; 2];
+        mty_runtime_encoding_hex_encode(
+            digest_slot[0],
+            digest_slot[1],
+            hex_slot.as_mut_ptr() as i64,
+        );
+        let hex = String::from_utf8(slot_bytes(&hex_slot)).unwrap();
+        assert_eq!(
+            hex,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn crypto_hmac_sha256_matches_known_vector() {
+        // RFC 4231 test case 2: key="Jefe", data="what do ya want for nothing?"
+        let key = b"Jefe";
+        let msg = b"what do ya want for nothing?";
+        let mut tag_slot = [0i64; 2];
+        mty_runtime_crypto_hmac_sha256(
+            key.as_ptr() as i64,
+            key.len() as i64,
+            msg.as_ptr() as i64,
+            msg.len() as i64,
+            tag_slot.as_mut_ptr() as i64,
+        );
+        let mut hex_slot = [0i64; 2];
+        mty_runtime_encoding_hex_encode(tag_slot[0], tag_slot[1], hex_slot.as_mut_ptr() as i64);
+        let hex = String::from_utf8(slot_bytes(&hex_slot)).unwrap();
+        assert_eq!(
+            hex,
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+    }
+
+    #[test]
+    fn encoding_base64_url_no_pad_roundtrips_known_vector() {
+        let data = [0xfbu8, 0xff, 0xbf];
+        let mut slot = [0i64; 2];
+        mty_runtime_encoding_base64_encode_url_no_pad(
+            data.as_ptr() as i64,
+            data.len() as i64,
+            slot.as_mut_ptr() as i64,
+        );
+        let s = String::from_utf8(slot_bytes(&slot)).unwrap();
+        // standard b64 "+/+/" -> url-safe no-pad "-_-_"
+        assert_eq!(s, "-_-_");
+    }
+
+    #[test]
+    fn crypto_symbols_registered_in_table() {
+        let st = symbol_table();
+        for name in [
+            "mty_runtime_crypto_sha256",
+            "mty_runtime_crypto_sha512",
+            "mty_runtime_crypto_blake3",
+            "mty_runtime_crypto_hmac_sha256",
+            "mty_runtime_encoding_hex_encode",
+            "mty_runtime_encoding_base64_encode",
+            "mty_runtime_encoding_base64_encode_url_no_pad",
+        ] {
+            assert!(
+                st.iter().any(|(n, _)| n == name),
+                "{name} missing from symbol_table"
+            );
+        }
     }
 
     // ---- v0.42 T4 — typed log/print/format surface tests -----------


### PR DESCRIPTION
Continues the native-backend completeness work toward closing the last `VecOfAggregate` conformance gaps (42/43). This lands the **mechanical crypto/encoding foundation**.

## Problem
The cranelift/native backend stubbed every `std.crypto.*` / `std.encoding.*` call through `mty_runtime_extern_call` (returns 0), so a digest→hex chain dereferenced null → SIGSEGV (`42_crypto_url`, `43_secure_session`).

## Added (native JIT + AOT)
- `std.crypto.sha256` / `sha512` / `blake3` / `hmac_sha256` (digests → `Bytes`)
- `std.encoding.hex.encode`
- `std.encoding.base64.encode` / `base64.encode_url_no_pad` (→ `String`)

## How
- Runtime ABI fns in `mty-runtime/codegen_abi.rs` call the **same RustCrypto crates the interpreter uses** (`sha2`/`hex`/`hmac`/`base64`/`blake3`), depended on **directly** — not via `mty-stdlib` — to avoid a dependency cycle. Each reads its `(ptr,len)` input(s) and writes a `(ptr,len)` result into a 16-byte slot; digest output is interned **raw** (no lossy UTF-8 round-trip).
- Codegen dispatches by `EffectInvoke` full-name (`is_native_crypto_encoding` + `emit_crypto_encoding_call`), modelled on the `std.fs` native path. No type wall (name-based dispatch).

## Validation
- `sha256("hello")` → `hex.encode` → correct digest in JIT.
- Known-answer vectors: SHA-256, HMAC-SHA256 (RFC 4231 case 2), base64url — 4 unit tests.
- Full `mty-codegen-cranelift` suite + conformance sweep green; clippy clean.

## Not yet (tracked under #297)
Does NOT flip 42/43 — they also need `std.url` / `std.uuid` / `std.regex` (opaque-struct codegen) and have a pre-existing interp dynamic-log gap. This is the foundation those build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)