### PR TITLE
v0.49: interp fall-back for non-native stdlib (fixes 42/43) + DX docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3336,12 +3336,16 @@ dependencies = [
 name = "mty-runtime"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
+ "blake3",
  "bumpalo",
  "ciborium",
  "criterion",
  "crossbeam-deque",
  "crossbeam-utils",
  "dashmap",
+ "hex",
+ "hmac 0.12.1",
  "libloading 0.9.0",
  "mty-diagnostics",
  "mty-driver",
@@ -3358,6 +3362,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@
 
 Compiler, runtime, formatter, package manager, doc generator, LSP,
 and stdlib all live in one Rust workspace and one `mty` binary.
-v0.48 is the current release: a Cranelift aggregate-codegen pass —
-struct field-assignment (sibling-safe writes + nested
-`o.inner.x = 7`), `Vec`-of-aggregate element sizing (`Vec[String]` no
-longer corrupts the heap), and native `String` constructors
-(`new`/`with_capacity`/`from_str`) that make the `26_string_vec`
-example run native at interpreter parity. Plus a permanent Windows-CI
-fix (a 6-hour serial-libtest hang → ~9 min via `cargo-nextest`).
+v0.49 is the current release: native `std.crypto` (SHA-256/512,
+BLAKE3, HMAC) + `std.encoding` (hex, base64) on the Cranelift path,
+plus a transparent interpreter fall-back for any stdlib without native
+codegen yet (`std.url`/`std.uuid`/`std.regex`/crypto-AEAD) — so
+`mty run` runs the program instead of crashing on an unimplemented
+surface. Closes the last `VecOfAggregate` examples (`42_crypto_url`,
+`43_secure_session`). Builds on the v0.48 aggregate-codegen pass
+(struct field-assignment, `Vec`-of-aggregate sizing, native `String`
+constructors) and the permanent Windows-CI fix.
 
 ## Why Mighty
 

--- a/crates/mty-cli/tests/conformance_examples.rs
+++ b/crates/mty-cli/tests/conformance_examples.rs
@@ -72,44 +72,11 @@ enum KnownReason {
     /// JIT segfaults. v0.42 work to either accept capability
     /// stubs or make codegen refuse the call cleanly.
     MainTakesCapabilities,
-    /// `Vec[T]` where `T` is an aggregate (`String`, `struct`, …).
-    ///
-    /// This is a LAYERED defect. v0.48 (#297) fixed three of the four
-    /// layers (all regression-free, verified by CLIF + this sweep):
-    ///   1. Push-only element inference — a Vec whose `T` was pinned
-    ///      only by `.push(x)` (no annotation / annotated return) left
-    ///      `T` an unresolved var. Fixed in mty-types: `Vec.new()` /
-    ///      `with_capacity()` now synth `Vec[?E]` and `push(x)` unifies
-    ///      `x` with `E`.
-    ///   2. `Vec.new()` result-temp typing — the temp holding the
-    ///      constructor was `IrTy::Error`, so `emit_vec_new` read the
-    ///      element size off an Error `current_dest_ty` and stored the
-    ///      8-byte fallback in the header. Fixed in mty-ir
-    ///      (`vec_call_result_ty`): the temp now carries the real
-    ///      `Vec[T]`, so the header records the true element size (16
-    ///      for `String`), and the element store memcpys the right width.
-    ///   3. (Consequence of 1+2) the grow-buffer allocation + element
-    ///      store now use a consistent, correct element size.
-    ///
-    ///   4. (v0.48 #297) Vec[String] element PUSH no longer SIGSEGVs for
-    ///      a valid String operand: `emit_vec_push` routes String/Str/
-    ///      Bytes elements through `string_pair` (correct for both the
-    ///      literal fast-path and the slot-backed case) instead of
-    ///      memcpy-from-operand-address. Validated: `Vec[String]` with
-    ///      literal pushes (`v.push("alpha")`) + `len()` now JIT-matches
-    ///      the interpreter. Lock-in tests in
-    ///      `crates/mty-codegen-cranelift/tests/vec_string_push_v048.rs`.
-    ///
-    /// REMAINING (still KNOWN_FAILING): native String codegen. The
-    /// examples build their strings via `String.from_str(...)` /
-    /// `with_capacity` / `new` and read them via `String.len()` /
-    /// `push_str` / `format!` — NONE of which have native cranelift
-    /// implementations (interp-only; `String.from_str` lowers to an
-    /// unhandled `BuiltinId::Extern` that yields garbage in JIT, so
-    /// `let s = String.from_str("a"); s.len()` gives interp 5 / JIT 0).
-    /// Flipping 26/42/43 needs the whole native-String surface, a
-    /// separate feature; this entry's fixes land the Vec-storage half.
-    VecOfAggregate,
+    // NOTE: the `VecOfAggregate` reason was retired in v0.49 — all three
+    // examples (26/42/43) now pass. 26 via the Vec-of-aggregate codegen
+    // fixes + native String constructors (v0.48); 42/43 via the
+    // interpreter fall-back for not-yet-native stdlib (v0.49). See the
+    // RELEASE notes + task #297 for the full history.
     /// v0.45 T1 native `std.fs` now actually touches disk under the
     /// JIT path. Examples that write to absolute hard-coded paths
     /// (`/tmp/...`) succeed under the interpreter's hosted dispatcher
@@ -182,14 +149,11 @@ const KNOWN_FAILING: &[KnownFailing] = &[
     // 26_string_vec FIXED in v0.48 (#297): Vec-of-aggregate sizing/push
     // + native String constructors (new/with_capacity/from_str) make it
     // JIT-match the interpreter.
-    KnownFailing {
-        name: "42_crypto_url",
-        reason: KnownReason::VecOfAggregate,
-    },
-    KnownFailing {
-        name: "43_secure_session",
-        reason: KnownReason::VecOfAggregate,
-    },
+    // 42_crypto_url + 43_secure_session FIXED in v0.49 (#297): they use
+    // stdlib with no native codegen yet (std.url/uuid/regex, crypto AEAD,
+    // random_bytes). `is_interpreter_hosted_stdlib` now routes those to a
+    // transparent interpreter fall-back instead of the silent stub that
+    // SIGSEGV'd, so `mty run` matches `mty run --legacy-interp`.
     // v0.45 T1 native std.fs exposes hard-coded absolute-path writes
     // that previously no-op'd under the interpreter's hosted dispatcher.
     // v0.46 follow-up rewrites these examples to use a per-run tempdir.

--- a/crates/mty-codegen-cranelift/src/lower.rs
+++ b/crates/mty-codegen-cranelift/src/lower.rs
@@ -4406,12 +4406,28 @@ impl<'short, 'long, 'a, 'm, 'p, 'd, M: Module> FnLower<'short, 'long, 'a, 'm, 'p
 }
 
 fn is_interpreter_hosted_stdlib(name: &str) -> bool {
-    // v0.45 T1 — `std.fs.*` no longer falls back to interpreter-hosted.
-    // The codegen routes those calls through `emit_fs_call` to the
-    // native ABI symbols. Any non-fs interpreter-hosted callsites
-    // continue to fail with the descriptive error (none today).
-    let _ = name;
-    false
+    // v0.49 — stdlib modules that have NO native Cranelift codegen yet.
+    // Returning `true` makes the EffectInvoke lowering report
+    // `CodegenError::Unsupported`, which `mty run` turns into a
+    // transparent fall-back to the interpreter (see `cmd::run::run`).
+    //
+    // Before this, an unimplemented stdlib call fell through to the
+    // silent `mty_runtime_extern_call` stub, which returns 0 — and the
+    // moment that 0 is dereferenced as an aggregate (a `Str`/`Bytes`/
+    // struct result) the program SIGSEGV'd with no diagnostic
+    // (`42_crypto_url` / `43_secure_session`). Routing to the
+    // interpreter runs the program correctly instead of crashing.
+    //
+    // The natively-lowered surfaces are dispatched BEFORE this check
+    // (`is_native_fs_method` → `emit_fs_call`; `is_native_crypto_encoding`
+    // → `emit_crypto_encoding_call`), so naming a whole module here only
+    // catches its NOT-yet-native methods: e.g. `crypto.sha256` is handled
+    // natively and never reaches us, while `crypto.aes_gcm.encrypt`
+    // falls back. As more methods go native, they simply stop reaching
+    // this function — no edit needed here.
+    let bare = name.strip_prefix("std.").unwrap_or(name);
+    let module = bare.split('.').next().unwrap_or("");
+    matches!(module, "url" | "uuid" | "regex" | "crypto" | "encoding")
 }
 
 /// v0.45 T1 — recognise the `std.fs.*` methods that the codegen

--- a/crates/mty-driver/tests/conformance_codegen.rs
+++ b/crates/mty-driver/tests/conformance_codegen.rs
@@ -252,7 +252,7 @@ fn all_examples_compile_native() {
         let syms = symbols_from(&st.iter().map(|(n, p)| (n.as_str(), *p)).collect::<Vec<_>>());
         if let Err(e) = build_jit(&prog, &syms) {
             let err = format!("{e}");
-            if is_interpreter_hosted_std_fs_codegen(&err) {
+            if is_interpreter_hosted_codegen(&err) {
                 continue;
             }
             failed.push((name, err));
@@ -270,8 +270,15 @@ fn all_examples_compile_native() {
     );
 }
 
-fn is_interpreter_hosted_std_fs_codegen(err: &str) -> bool {
-    err.contains("std.fs.") && err.contains("is interpreter-hosted")
+/// True when native codegen refused a call because the stdlib surface
+/// has no Cranelift lowering yet (`mty run` falls back to the
+/// interpreter for these — see `is_interpreter_hosted_stdlib` in the
+/// codegen crate). v0.49: generalised from `std.fs` to any module
+/// (`std.url`/`std.uuid`/`std.regex`/crypto AEAD/`random_bytes`/…) so
+/// examples that legitimately can't AOT-compile aren't flagged as
+/// codegen regressions.
+fn is_interpreter_hosted_codegen(err: &str) -> bool {
+    err.contains("is interpreter-hosted")
 }
 
 /// JIT-run smoke: for each adt/match/result/agent/mono case, JIT the

--- a/dev/history/releases/RELEASE-v0.49.md
+++ b/dev/history/releases/RELEASE-v0.49.md
@@ -1,0 +1,80 @@
+# Mighty v0.49 Release Notes
+
+**Tag:** `v0.49.0`
+**Date:** 2026-06-04
+**Status:** SHIPPED — native `std.crypto` + `std.encoding` codegen, plus
+a transparent interpreter fall-back for not-yet-native stdlib that
+clears the last two `VecOfAggregate` conformance examples.
+
+**Headline:** Mighty v0.49 — native crypto/encoding + graceful stdlib
+fall-back: `mty run` now hashes and encodes on the Cranelift path, and
+any stdlib surface without native codegen runs the program through the
+interpreter instead of crashing (marquee: examples `42_crypto_url` and
+`43_secure_session` now pass — the `VecOfAggregate` class is fully
+closed).
+
+## Summary
+
+v0.49 finishes the native-stdlib correctness story the v0.48 codegen
+pass opened. The native Cranelift backend gains real `std.crypto`
+(SHA-256/512, BLAKE3, HMAC-SHA-256) and `std.encoding` (hex, base64,
+base64url) lowerings, calling the same RustCrypto crates the
+interpreter uses. Just as importantly, the backend stops *silently
+crashing* on stdlib it hasn't lowered yet: `is_interpreter_hosted_stdlib`
+now routes `std.url` / `std.uuid` / `std.regex` / crypto-AEAD /
+`random_bytes` (and the other interpreter-only modules) to a
+`CodegenError::Unsupported`, which `mty run` turns into a transparent
+per-program interpreter fall-back. The program runs correctly instead
+of dereferencing a stubbed null pointer — which is exactly what made
+examples 42/43 SIGSEGV. With both halves in place, all three
+`VecOfAggregate` examples (26/42/43) now pass at interpreter parity.
+
+## Shipped
+
+- **Native `std.crypto` + `std.encoding` (PR #41).** New runtime ABI
+  functions in `mty-runtime/codegen_abi.rs` —
+  `mty_runtime_crypto_{sha256,sha512,blake3,hmac_sha256}` and
+  `mty_runtime_encoding_{hex_encode,base64_encode,base64_encode_url_no_pad}`
+  — backed by `sha2`/`hex`/`hmac`/`base64`/`blake3` depended on
+  directly (not via `mty-stdlib`, to avoid a dependency cycle). Digests
+  return raw `Bytes`, encoders return `String`; both pipe through the
+  existing `(ptr,len)` aggregate model so a `hex.encode(sha256(x))`
+  chain JITs end-to-end. Codegen dispatches by `EffectInvoke` full-name
+  (`is_native_crypto_encoding` → `emit_crypto_encoding_call`). Validated
+  with known-answer vectors (SHA-256, HMAC-SHA-256 RFC 4231, base64url).
+
+- **Transparent interpreter fall-back for not-yet-native stdlib.**
+  `is_interpreter_hosted_stdlib` previously returned `false` for
+  everything, so an unimplemented stdlib call hit the silent
+  `mty_runtime_extern_call` stub (returns 0) and SIGSEGV'd the instant
+  the 0 was used as an aggregate result. It now reports the call as
+  interpreter-hosted, and `mty run` (see `cmd::run::run`) falls back to
+  the interpreter for the whole program — same capability checks and
+  output as `--legacy-interp`, no crash. **Examples `42_crypto_url` and
+  `43_secure_session` now pass** and are removed from `KNOWN_FAILING`;
+  the `VecOfAggregate` class is fully closed.
+
+- **DX docs refresh.** `docs/reference/cli/mty-run.md` now states the
+  real native coverage (`std.fs`, `std.crypto` digests, `std.encoding`
+  encoders run natively; everything else falls back transparently),
+  replacing the stale pre-v0.45 "fs falls back to the interpreter" note.
+
+## Carry-forward priorities
+
+- **More native stdlib** (so these surfaces run on the Cranelift path
+  rather than falling back): `std.url` parse/builder, `std.uuid` v4/v7,
+  `std.regex`, crypto AEAD (`aes_gcm`, `chacha20_poly1305`) and
+  `random_bytes`, the `std.encoding` decoders. These return structs the
+  caller field-accesses, so they need opaque-handle codegen + runtime
+  accessor functions (model on the `DirIter` handle) — tracked in #297.
+- **Native `String` methods** (`len`/`push_str`/…) — needs the String
+  value-model rework (typing String bindings currently breaks struct
+  `String` fields, e.g. example 28); recorded in #297.
+- Pending tasks #253 (SWE-bench), #262 (BOLT training profile path).
+
+## Acknowledgements
+
+The fall-back fix turns a class of mystery segfaults into "it just
+runs": any stdlib the native backend can't lower yet now degrades to
+the interpreter transparently, so adding native coverage is a pure
+performance/optionality improvement rather than a correctness gate.

--- a/docs/reference/cli/mty-run.md
+++ b/docs/reference/cli/mty-run.md
@@ -107,12 +107,28 @@ hi
 
 ## Effect handling
 
-Effect calls (`std.fs.read`, `std.fs.write`, `std.fs.exists`,
-`std.fs.list_dir`, and their documented aliases) are routed through
-the runtime's host dispatcher. If the native Cranelift path reaches a
-host-backed filesystem call, `mty run` falls back to the interpreter
-so the operation uses the same capability checks and real file I/O as
-`--legacy-interp`.
+`mty run` JIT-compiles with Cranelift and falls back to the interpreter
+per-program for any stdlib surface that does not yet have native
+codegen. The fall-back is transparent: the program runs and produces
+the same result as `--legacy-interp` — you never see a crash for an
+unimplemented surface.
+
+**Lowered natively** (run on the Cranelift path):
+
+- `std.fs.*` — `read`, `read_to_string`, `read_dir` / `list_dir`,
+  `write`, `exists`, `metadata`, the `read_dir` iterator, and their
+  documented aliases, via the runtime's native ABI symbols.
+- `std.crypto` digests — `sha256`, `sha512`, `blake3`, `hmac_sha256`.
+- `std.encoding` encoders — `hex.encode`, `base64.encode`,
+  `base64.encode_url_no_pad`.
+
+**Interpreter-hosted** (the whole program transparently falls back to
+the interpreter when one of these is called): `std.url`, `std.uuid`,
+`std.regex`, `std.crypto` AEAD (`aes_gcm`, `chacha20_poly1305`) and
+`random_bytes`, the `std.encoding` decoders, and other not-yet-native
+stdlib modules. These run with the same capability checks and behaviour
+as `--legacy-interp`; native codegen for them is incremental
+(see `dev/history/releases/`).
 
 ## Related commands
 


### PR DESCRIPTION
Fixes a real DX bug, closes the last two `VecOfAggregate` conformance examples, and refreshes the stale native-coverage docs.

## DX bug: native build silently SIGSEGV'd on unimplemented stdlib
`is_interpreter_hosted_stdlib()` returned `false` for everything, so a native (`mty run`) program calling a stdlib surface with no Cranelift codegen yet — `std.url`, `std.uuid`, `std.regex`, crypto AEAD, `random_bytes` — fell through to the silent `mty_runtime_extern_call` stub, got `0` back, and **SIGSEGV'd** the instant that `0` was used as an aggregate result. A raw crash with zero diagnostic (examples `42_crypto_url` / `43_secure_session`).

## Fix: transparent interpreter fall-back
List those modules in `is_interpreter_hosted_stdlib`, so the `EffectInvoke` lowering reports `CodegenError::Unsupported`, which `cmd::run::run` **already** turns into a per-program interpreter fall-back. The program now runs correctly (same as `--legacy-interp`) instead of crashing. Natively-lowered surfaces (`fs.*`, crypto digests/HMAC, `encoding` hex/base64) are dispatched *before* this check, so naming a whole module only catches its not-yet-native methods — they stop reaching the check as they go native (no edit needed).

## Result
- **Examples `42_crypto_url` + `43_secure_session` now pass** (JIT matches the interpreter via fall-back) — removed from `KNOWN_FAILING`. The `VecOfAggregate` class (26/42/43) is **fully closed** (retired the dead reason variant).
- cranelift suite + conformance sweep + floor all green; clippy clean.

## Docs / DX
- `docs/reference/cli/mty-run.md` — refreshed the native-coverage section (was the stale pre-v0.45 "fs falls back to the interpreter" note).
- README bumped to v0.49.
- Added `RELEASE-v0.49.md` (native crypto/encoding from #41 + this fall-back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)