### PR TITLE
docs: unblock Pages deploy + refresh to v0.49; playground version pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ For the full per-release notes, see
 
 ## [Unreleased]
 
+## [0.49.0] - 2026-06-04
+
+Native `std.crypto` (SHA-256/512, BLAKE3, HMAC-SHA-256) and
+`std.encoding` (hex, base64, base64url) codegen on the Cranelift path,
+plus a transparent interpreter fall-back for stdlib without native
+codegen yet (`std.url`/`std.uuid`/`std.regex`, crypto AEAD,
+`random_bytes`): `mty run` runs the program instead of silently
+SIGSEGV'ing on an unimplemented surface, and `mty build` reports a clean
+compile error rather than a runtime crash. Closes the last
+`VecOfAggregate` conformance examples (`42_crypto_url`,
+`43_secure_session`). Refreshed the `mty run` native-coverage docs.
+
+## [0.48.0] - 2026-06-03
+
+A Cranelift aggregate-codegen pass: struct field-assignment
+(sibling-safe writes + nested `o.inner.x = 7`), `Vec`-of-aggregate
+element sizing (`Vec[String]` no longer corrupts the heap), and native
+`String` constructors (`new`/`with_capacity`/`from_str`) that make the
+`26_string_vec` example run native at interpreter parity. Plus a
+permanent Windows-CI fix (a ~6-hour serial-libtest hang → ~9 min via
+`cargo-nextest`).
+
+## [0.47.0] - 2026-06-03
+
+Caller-allocated FFI OUT buffers (`extern c fn f(out: mut Vec[U8])`
+lowered to a `(ptr, capacity, *len)` triple), LLVM `lower_assign`
+projection-into-aggregate stores at parity with Cranelift, runtime ABI
+header numeric version macros + `@since`/`@deprecated` markers, `std.fs`
+DirIter scope-end auto-Drop (`read_dir_lines` retired), and the LSP
+`WorkspaceEdit` `documentChanges` migration for rename + codeAction.
+
 ## [0.46.0] - 2026-06-02
 
 v0.46 ships the official runtime ABI artifact pipeline (downstream

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Mighty is a statically typed, ownership-based, agent-first systems
 language that compiles to native code and to WebAssembly components.
-These docs cover the language at toolchain **v0.42** tracking
+These docs cover the language at toolchain **v0.49** tracking
 spec **v1.0-RC5**.
 
 > **Pre-1.0 warning.** The language surface is frozen for v1.0 but
@@ -84,18 +84,18 @@ spec **v1.0-RC5**.
 - [Upstream issues](upstream-issues/) — bugs filed against
   Cranelift / wasmtime / etc. that affect Mighty.
 
-## Status snapshot (v0.42, v0.43 in progress)
+## Status snapshot (v0.49)
 
 | Component                            | State                                            |
 |--------------------------------------|--------------------------------------------------|
 | Lexer, parser, CST                   | shipped                                          |
 | Typed AST + HIR + lowering           | shipped                                          |
 | Diagnostics engine                   | shipped                                          |
-| Formatter (per-node)                 | shipped; v0.43 starts syntax-aware top-level `const` formatting |
+| Formatter (per-node + decls)         | shipped (v0.45 fn/struct/enum/type decls)        |
 | Type checker                         | shipped                                          |
 | Borrow / move / affine checker       | shipped                                          |
 | Effect / capability checker          | shipped                                          |
-| Codegen (Cranelift) native           | shipped; v0.42 fixed typed log + Vec liveness, v0.43 adds truthful link diagnostics |
+| Codegen (Cranelift) native           | shipped; v0.48 struct field-assignment + `Vec`-of-aggregate; v0.49 native `std.crypto`/`std.encoding` + interp fall-back for not-yet-native stdlib |
 | Codegen (Wasm) P2 + cabi_realloc     | shipped (v0.18)                                  |
 | Codegen (LLVM)                       | opt-in backend                                   |
 | Runtime (scheduler, mailboxes)       | shipped                                          |
@@ -107,18 +107,20 @@ spec **v1.0-RC5**.
 | Replay (`mty replay --byte-identical`)| shipped (v0.17/18)                              |
 | Cluster (distributed agents)         | shipped (v0.18 Tier 4.1)                         |
 | LLM-agent stack (std.llm/mcp/memory/swarm) | shipped (v0.26–v0.30)                      |
-| Extern C + `[[extern_lib]]`          | shipped (v0.36 T2); v0.43 reports real linker failures distinctly from missing linkers |
+| Extern C + `[[extern_lib]]`          | shipped (v0.36 T2; v0.46 truthful linker-failure vs missing-linker diagnostics) |
 | String position/range ops + MT5080   | shipped (v0.36 T3)                               |
 | Stardust→Mighty rebrand compat       | shipped (v0.36 T4 — STARDUST_* env legacy)       |
 | PGO release binaries                 | shipped (v0.36 T5 — Linux + macOS-x86_64 + Win)  |
 | `mty find` / `mty fix` / `mty hooks` | shipped (v0.33/v0.34/v0.35)                      |
 | Self-host (lexer..min-typeck)        | 40/40 tests passing                              |
 
-Current v0.43 candidates are driven by the Mighty IDE lessons log:
-short-circuit logical lowering, interpreter writeback for
-statement-form `Vec`/`String` mutators, top-level `const` formatting,
-prefix-call parsing, and native link diagnostics.
+Current work (post-v0.49) extends the native Cranelift backend:
+native codegen for `std.url` / `std.uuid` / `std.regex` / crypto AEAD
+(today they transparently fall back to the interpreter), and native
+`String` methods.
 
 See
 [`CHANGELOG.md`](https://github.com/hassard0/Mighty/blob/main/CHANGELOG.md)
-at the repo root for the full release history.
+at the repo root (and the per-release notes under
+[`dev/history/releases/`](https://github.com/hassard0/Mighty/tree/main/dev/history/releases))
+for the full release history.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -334,7 +334,7 @@ is the canonical list of what's enforced.
 
 ### Is Mighty production ready?
 
-**No.** The spec is RC5 and the toolchain is v0.30 (pre-1.0). It
+**No.** The spec is RC5 and the toolchain is v0.49 (pre-1.0). It
 is stable enough for hobby projects, learning, and demos. It is
 not yet stable enough to bet a paycheque on. Open issues for
 rough edges; they will be triaged for v1.0.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This page walks through installing the Mighty compiler, scaffolding
 a package, running your first program, writing your first agent,
 running your first test, and pointing you at the next read.
 
-> **Pre-alpha status.** Mighty is at **v0.42.0** (toolchain)
+> **Pre-alpha status.** Mighty is at **v0.49.0** (toolchain)
 > tracking spec **v1.0-RC5**. The language surface is feature-
 > complete for v1.0 and frozen pending the eight open RFC comment
 > windows. Pre-built binaries ship on every release; treat the
@@ -20,7 +20,7 @@ The fastest path. Releases page:
 x86_64, macOS arm64, and Windows x86_64.
 
 ```bash
-# Linux / macOS — replace <v> with the latest tag (e.g. v0.42.0).
+# Linux / macOS — replace <v> with the latest tag (e.g. v0.49.0).
 curl -L https://github.com/hassard0/Mighty/releases/download/<v>/mty-<v>-linux-x86_64.tar.gz | tar xz
 sudo mv mty /usr/local/bin/
 mty --version

--- a/docs/reference/cli/mty-check.md
+++ b/docs/reference/cli/mty-check.md
@@ -93,7 +93,7 @@ protocol. See
 [`docs/internals/diagnostic-envelopes.md`](../../internals/diagnostic-envelopes.md)
 for the envelope schema. The simpler structured-result shape above is
 documented in
-[`crates/mty-diagnostics/src/fix.rs`](../../../crates/mty-diagnostics/src/fix.rs)
+[`crates/mty-diagnostics/src/fix.rs`](https://github.com/hassard0/Mighty/blob/main/crates/mty-diagnostics/src/fix.rs)
 (`CheckResult` / `CheckDiagnostic`).
 
 ## Examples

--- a/tools/playground/index.html
+++ b/tools/playground/index.html
@@ -16,7 +16,7 @@
       <div class="topbar__brand">
         <span class="topbar__logo" aria-hidden="true">m</span>
         <span class="topbar__title">Mighty Playground</span>
-        <span class="topbar__version" id="version-pill">v0.33</span>
+        <span class="topbar__version" id="version-pill">v0.49</span>
       </div>
       <nav class="topbar__nav">
         <select id="example-picker" aria-label="Load example">


### PR DESCRIPTION
## The Pages site (and playground) hadn't been deploying
`pages.yml` builds + publishes both the docs site **and** the playground (the comment in `playground.yml` confirms "the real publish path is pages.yml"). It was **failing** on every recent push: `mkdocs build --strict` aborted on a single broken link in `docs/reference/cli/mty-check.md` (a relative link to `crates/mty-diagnostics/src/fix.rs`, a source file outside the docs tree). Converted it to a GitHub blob URL (the established pattern). **`mkdocs build --strict` now passes locally — 0 warnings.** Pushing to main re-runs the deploy, republishing the docs site + playground (with the current v0.49 `mty-cli` WASM).

## Version refresh (docs were pinned at v0.42/v0.43, 7 releases stale)
- `docs/getting-started.md`: v0.42.0 → v0.49.0 (status + install example).
- `docs/README.md`: toolchain v0.42 → v0.49; status-snapshot title; codegen-native row now lists v0.48 struct/Vec-of-aggregate + v0.49 native crypto/encoding + interp fall-back; retired the "v0.43 in progress" forward-looking notes; restored the `CHANGELOG.md` reference.
- `CHANGELOG.md`: added the missing **[0.47.0] / [0.48.0] / [0.49.0]** entries (it had stopped at 0.46.0).
- `tools/playground/index.html`: version pill **v0.33 → v0.49**.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)